### PR TITLE
multiple bug fixes and 2 improvements

### DIFF
--- a/Assets/Animations/Player/Player.controller
+++ b/Assets/Animations/Player/Player.controller
@@ -133,6 +133,37 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1101 &-8658097171260178548
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: FirstAttack
+    m_EventTreshold: 0
+  - m_ConditionMode: 1
+    m_ConditionEvent: IsJumping
+    m_EventTreshold: 0
+  - m_ConditionMode: 3
+    m_ConditionEvent: Vertical
+    m_EventTreshold: 0.1
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -8929480393705421897}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0.16666669
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &-8377903487103705446
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -645,10 +676,10 @@ AnimatorStateMachine:
     m_Position: {x: 400, y: 990, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -8929480393705421897}
-    m_Position: {x: 1000, y: 250, z: 0}
+    m_Position: {x: 990, y: 250, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -8957230719868873905}
-    m_Position: {x: 1000, y: 330, z: 0}
+    m_Position: {x: 1000, y: 350, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions:
   - {fileID: -134292405013456112}
@@ -868,85 +899,91 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: SpeedY
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Horizontal
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Vertical
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
+  - m_Name: IsAttacking
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
   - m_Name: FirstAttack
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: IsDoingSecondAttack
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Jump
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Dash
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: IsDashing
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Death
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: IsDead
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: IsJumping
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: IsWallSliding
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Hurt
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -960,6 +997,37 @@ AnimatorController:
     m_IKPass: 0
     m_SyncedLayerAffectsTiming: 0
     m_Controller: {fileID: 9100000}
+--- !u!1101 &194094643333608855
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: IsJumping
+    m_EventTreshold: 0
+  - m_ConditionMode: 1
+    m_ConditionEvent: FirstAttack
+    m_EventTreshold: 0
+  - m_ConditionMode: 4
+    m_ConditionEvent: Vertical
+    m_EventTreshold: -0.1
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -8957230719868873905}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0.16666669
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &395853119012657328
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -1218,6 +1286,8 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: -8703611230565380980}
+  - {fileID: -8658097171260178548}
+  - {fileID: 194094643333608855}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -1297,6 +1367,9 @@ AnimatorStateTransition:
     m_EventTreshold: -3
   - m_ConditionMode: 2
     m_ConditionEvent: IsDead
+    m_EventTreshold: 0
+  - m_ConditionMode: 2
+    m_ConditionEvent: IsAttacking
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 1602210007712739655}

--- a/Assets/Prefabs/Characters/Enemies/Archer/Forest Ranger - No Jump.prefab
+++ b/Assets/Prefabs/Characters/Enemies/Archer/Forest Ranger - No Jump.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &48215384
+--- !u!1 &2957183604436015033
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,38 +8,38 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 48215385}
-  - component: {fileID: 48215387}
-  - component: {fileID: 48215386}
+  - component: {fileID: 2957183604436015014}
+  - component: {fileID: 2957183604436015012}
+  - component: {fileID: 2957183604436015015}
   m_Layer: 0
-  m_Name: GroundCheck
+  m_Name: WalkAwayCheck
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &48215385
+--- !u!4 &2957183604436015014
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 48215384}
+  m_GameObject: {fileID: 2957183604436015033}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: -0.23118567, z: 0}
+  m_LocalPosition: {x: -0.35, y: -0.23744959, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 771548696854713196}
-  m_RootOrder: 7
+  m_Father: {fileID: 2957183605891938225}
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!58 &48215387
+--- !u!58 &2957183604436015012
 CircleCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 48215384}
+  m_GameObject: {fileID: 2957183604436015033}
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
@@ -49,13 +49,13 @@ CircleCollider2D:
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
   m_Radius: 0.05
---- !u!114 &48215386
+--- !u!114 &2957183604436015015
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 48215384}
+  m_GameObject: {fileID: 2957183604436015033}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 661ac1d486f89174f9d7d43fd300f07e, type: 3}
@@ -64,7 +64,7 @@ MonoBehaviour:
   isColliding: 0
   tagsToCheck:
   - Ground
---- !u!1 &303674431
+--- !u!1 &2957183604744304425
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -72,37 +72,112 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 303674432}
-  - component: {fileID: 303674433}
+  - component: {fileID: 2957183604744304406}
+  - component: {fileID: 2957183604744304404}
+  - component: {fileID: 2957183604744304407}
   m_Layer: 0
-  m_Name: GroupAlertCollider
+  m_Name: AttackZoneCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &303674432
+--- !u!4 &2957183604744304406
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 303674431}
+  m_GameObject: {fileID: 2957183604744304425}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 771548696854713196}
-  m_RootOrder: 6
+  m_Father: {fileID: 2957183605891938225}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!61 &303674433
+--- !u!61 &2957183604744304404
 BoxCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 303674431}
+  m_GameObject: {fileID: 2957183604744304425}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 1.9692972, y: 0.023116708}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 4.151771, y: 4.192857}
+  m_EdgeRadius: 0
+--- !u!114 &2957183604744304407
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2957183604744304425}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c693660466f7ac04ea8cbdde54a5deba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  isColliding: 0
+  tagsToCheck:
+  - Player
+--- !u!1 &2957183605584680045
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2957183605584680042}
+  - component: {fileID: 2957183605584680040}
+  - component: {fileID: 2957183605584680043}
+  m_Layer: 0
+  m_Name: GroundCheck
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2957183605584680042
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2957183605584680045}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.23744959, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2957183605891938225}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &2957183605584680040
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2957183605584680045}
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
@@ -110,19 +185,24 @@ BoxCollider2D:
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 4, y: 1}
-  m_EdgeRadius: 0
---- !u!1 &771548696423926449
+  m_Radius: 0.05
+--- !u!114 &2957183605584680043
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2957183605584680045}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 661ac1d486f89174f9d7d43fd300f07e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  isColliding: 0
+  tagsToCheck:
+  - Ground
+--- !u!1 &2957183605671449916
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -130,32 +210,63 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 771548696423926448}
+  - component: {fileID: 2957183605671449917}
+  - component: {fileID: 2957183605671449915}
+  - component: {fileID: 2957183605671449914}
   m_Layer: 0
-  m_Name: Sword
-  m_TagString: Sword
+  m_Name: StillMoreToWalkCheck
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &771548696423926448
+--- !u!4 &2957183605671449917
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771548696423926449}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_GameObject: {fileID: 2957183605671449916}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.35, y: -0.23744959, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 771548697724702992}
-  - {fileID: 771548698115832071}
-  m_Father: {fileID: 771548696854713196}
-  m_RootOrder: 0
+  m_Children: []
+  m_Father: {fileID: 2957183605891938225}
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &771548696530122667
+--- !u!58 &2957183605671449915
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2957183605671449916}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.05
+--- !u!114 &2957183605671449914
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2957183605671449916}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 661ac1d486f89174f9d7d43fd300f07e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  isColliding: 0
+  tagsToCheck:
+  - Ground
+--- !u!1 &2957183605755421288
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -163,8 +274,8 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 771548696530122666}
-  - component: {fileID: 771548696530122668}
+  - component: {fileID: 2957183605755421289}
+  - component: {fileID: 2957183605755421270}
   m_Layer: 0
   m_Name: VisionFieldCollider
   m_TagString: Untagged
@@ -172,35 +283,35 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &771548696530122666
+--- !u!4 &2957183605755421289
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771548696530122667}
+  m_GameObject: {fileID: 2957183605755421288}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 771548696854713196}
+  m_Father: {fileID: 2957183605891938225}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!61 &771548696530122668
+--- !u!61 &2957183605755421270
 BoxCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771548696530122667}
+  m_GameObject: {fileID: 2957183605755421288}
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
   m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 1.429939, y: 0.69939816}
+  m_Offset: {x: 1.9692972, y: 0.023116708}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0, y: 0}
@@ -211,9 +322,9 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 3.0730546, y: 1.8209717}
+  m_Size: {x: 4.151771, y: 4.192857}
   m_EdgeRadius: 0
---- !u!1 &771548696854713193
+--- !u!1 &2957183605891938226
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -221,55 +332,55 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 771548696854713196}
-  - component: {fileID: 771548696854713197}
-  - component: {fileID: 771548696854713194}
-  - component: {fileID: 771548696854713195}
-  - component: {fileID: 771548696854713192}
-  - component: {fileID: 771548696854713184}
-  - component: {fileID: 771548696854713198}
-  - component: {fileID: 771548696854713185}
-  - component: {fileID: 1076851815}
-  - component: {fileID: 1978429411817555222}
+  - component: {fileID: 2957183605891938225}
+  - component: {fileID: 2957183605891938224}
+  - component: {fileID: 2957183605891938227}
+  - component: {fileID: 2957183605891938232}
+  - component: {fileID: 2957183605891938235}
+  - component: {fileID: 2957183605891938234}
+  - component: {fileID: 2957183605891938237}
+  - component: {fileID: 2957183605891938239}
+  - component: {fileID: 2957183605891938238}
+  - component: {fileID: 2957183605891938236}
   m_Layer: 8
-  m_Name: Medieval Warrior
+  m_Name: Forest Ranger - No Jump
   m_TagString: Enemy
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &771548696854713196
+--- !u!4 &2957183605891938225
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771548696854713193}
+  m_GameObject: {fileID: 2957183605891938226}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 3.2628043, y: -0.7188143, z: 0}
+  m_LocalPosition: {x: 2.71, y: -0.72227234, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 771548696423926448}
-  - {fileID: 771548697013693309}
-  - {fileID: 771548696530122666}
-  - {fileID: 771548698097287244}
-  - {fileID: 4644685787510159637}
-  - {fileID: 771548697458528305}
-  - {fileID: 303674432}
-  - {fileID: 48215385}
-  - {fileID: 1334871721644376303}
-  - {fileID: 360719255234833964}
+  - {fileID: 2957183604744304406}
+  - {fileID: 2957183606304197320}
+  - {fileID: 2957183605755421289}
+  - {fileID: 2957183606066013611}
+  - {fileID: 2957183604436015014}
+  - {fileID: 2957183605671449917}
+  - {fileID: 2957183606371556817}
+  - {fileID: 2957183605584680042}
+  - {fileID: 4975512656714291628}
+  - {fileID: 1307318236807199043}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &771548696854713197
+--- !u!212 &2957183605891938224
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771548696854713193}
+  m_GameObject: {fileID: 2957183605891938226}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -304,28 +415,28 @@ SpriteRenderer:
   m_SortingLayerID: -566649837
   m_SortingLayer: 4
   m_SortingOrder: 0
-  m_Sprite: {fileID: -1872766814, guid: 9e8cf9aeb46474e40b672c3141afb28e, type: 3}
+  m_Sprite: {fileID: 1331891882, guid: 37d772cffbe59b44a9e4de2cf9f2f2af, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 1.35, y: 1.35}
+  m_Size: {x: 1, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!95 &771548696854713194
+--- !u!95 &2957183605891938227
 Animator:
   serializedVersion: 4
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771548696854713193}
+  m_GameObject: {fileID: 2957183605891938226}
   m_Enabled: 1
   m_Avatar: {fileID: 0}
-  m_Controller: {fileID: 9100000, guid: 29e12f3c7ecd17b439875a1ad650c68f, type: 2}
+  m_Controller: {fileID: 9100000, guid: ec2fbad758d50744ba245b07832d8d9b, type: 2}
   m_CullingMode: 0
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
@@ -335,14 +446,14 @@ Animator:
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorControllerStateOnDisable: 0
---- !u!50 &771548696854713195
+--- !u!50 &2957183605891938232
 Rigidbody2D:
   serializedVersion: 4
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771548696854713193}
+  m_GameObject: {fileID: 2957183605891938226}
   m_BodyType: 0
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
@@ -356,118 +467,114 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 4
---- !u!70 &771548696854713192
+--- !u!70 &2957183605891938235
 CapsuleCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771548696854713193}
+  m_GameObject: {fileID: 2957183605891938226}
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: -0.006873131, y: -0.012028098}
-  m_Size: {x: 0.1958332, y: 0.4398328}
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 0.18104601, y: 0.3712545}
   m_Direction: 0
---- !u!114 &771548696854713184
+--- !u!114 &2957183605891938234
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771548696854713193}
+  m_GameObject: {fileID: 2957183605891938226}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8fc4d5af0feacf24da431439066d3099, type: 3}
+  m_Script: {fileID: 11500000, guid: 454330d883b138d49ba8350c600ad743, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  attackZoneCollider: {fileID: 771548697013693308}
-  startleDuration: 0.5
-  attackDelay: 0.1
---- !u!114 &771548696854713198
+  attackZoneCollider: {fileID: 2957183604744304407}
+  dangerZoneCollider: {fileID: 2957183606304197321}
+  startleDuration: 1
+--- !u!114 &2957183605891938237
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771548696854713193}
+  m_GameObject: {fileID: 2957183605891938226}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0b51727b4cfeca44591924a5e131ef65, type: 3}
+  m_Script: {fileID: 11500000, guid: c193fb0bd9c8cca46b74ec0e1f997fdd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  animationClips:
-  - {fileID: 7400000, guid: 4667812ea66582849bbedc30a748a852, type: 2}
-  - {fileID: 7400000, guid: 27108073f599823428f4489c75a6f175, type: 2}
-  - {fileID: 7400000, guid: 60857eecc7c2cf240ae73f0824107fd7, type: 2}
+  arrowAnimationClip: {fileID: 7400000, guid: 33ba12ab319d1694b94b63289b95dfb1, type: 2}
   attackCooldownDuration: 3
-  hasSecondAttack: 1
-  hasThirdAttack: 1
---- !u!114 &771548696854713185
+  arrowPrefab: {fileID: 4554462955417439476, guid: 04d5739dc3c1b6748820e6225f94623c, type: 3}
+--- !u!114 &2957183605891938239
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771548696854713193}
+  m_GameObject: {fileID: 2957183605891938226}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c80af2e2caee70648958283479c7dbf0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  particlesJump: {fileID: 5119220144170851674}
-  particlesLand: {fileID: 6594326574005602299}
-  groundCheck: {fileID: 48215386}
-  walkAwayCheck: {fileID: 8920816655398638726}
-  stillMoreToWalkCheck: {fileID: 771548697458528304}
-  jumpBackGroundCheck: {fileID: 771548698097287247}
-  dashForce: 400
+  particlesJump: {fileID: 932740076738071800}
+  particlesLand: {fileID: 252801715521905154}
+  groundCheck: {fileID: 2957183605584680043}
+  walkAwayCheck: {fileID: 2957183604436015015}
+  stillMoreToWalkCheck: {fileID: 2957183605671449914}
+  jumpBackGroundCheck: {fileID: 2957183606066013608}
+  dashForce: 850
   walkAwayDuration: 1.5
   runSpeed: 2
-  hasJumpBack: 1
+  hasJumpBack: 0
   hasDash: 0
-  walksAwayWhenInAttackCooldown: 0
+  walksAwayWhenInAttackCooldown: 1
   movesWhileAttacking: 0
---- !u!114 &1076851815
+--- !u!114 &2957183605891938238
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771548696854713193}
+  m_GameObject: {fileID: 2957183605891938226}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: aed2727e8c47bc44d82ee5f192799537, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  visionFieldCollider: {fileID: 771548696530122668}
-  groupAlertCollider: {fileID: 303674433}
+  visionFieldCollider: {fileID: 2957183605755421270}
+  groupAlertCollider: {fileID: 2957183606371556830}
   enemyLayer:
     serializedVersion: 2
     m_Bits: 256
   playerLayer:
     serializedVersion: 2
     m_Bits: 512
---- !u!114 &1978429411817555222
+--- !u!114 &2957183605891938236
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771548696854713193}
+  m_GameObject: {fileID: 2957183605891938226}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 2e58c267cd4ef09409f30c564b9ca1d6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  animator: {fileID: 771548696854713194}
+  animator: {fileID: 2957183605891938227}
   currentHitPoints: 1
   maxHitPoints: 1
   immuneTime: 2
---- !u!1 &771548697013693306
+--- !u!1 &2957183606066013610
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -475,45 +582,109 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 771548697013693309}
-  - component: {fileID: 771548697013693311}
-  - component: {fileID: 771548697013693308}
+  - component: {fileID: 2957183606066013611}
+  - component: {fileID: 2957183606066013609}
+  - component: {fileID: 2957183606066013608}
   m_Layer: 0
-  m_Name: AttackZoneCollider
+  m_Name: JumpBackGroundCheck
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &771548697013693309
+--- !u!4 &2957183606066013611
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771548697013693306}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_GameObject: {fileID: 2957183606066013610}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -1.61, y: -0.23744959, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 771548696854713196}
-  m_RootOrder: 1
+  m_Father: {fileID: 2957183605891938225}
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!61 &771548697013693311
-BoxCollider2D:
+--- !u!58 &2957183606066013609
+CircleCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771548697013693306}
+  m_GameObject: {fileID: 2957183606066013610}
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
   m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0.06408942, y: 0.06909001}
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.05
+--- !u!114 &2957183606066013608
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2957183606066013610}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 661ac1d486f89174f9d7d43fd300f07e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  isColliding: 0
+  tagsToCheck:
+  - Ground
+--- !u!1 &2957183606304197323
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2957183606304197320}
+  - component: {fileID: 2957183606304197302}
+  - component: {fileID: 2957183606304197321}
+  m_Layer: 0
+  m_Name: DangerZoneCollider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2957183606304197320
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2957183606304197323}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2957183605891938225}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &2957183606304197302
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2957183606304197323}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0, y: 0}
@@ -524,15 +695,15 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 0.79943633, y: 0.54424036}
+  m_Size: {x: 3.5, y: 1}
   m_EdgeRadius: 0
---- !u!114 &771548697013693308
+--- !u!114 &2957183606304197321
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771548697013693306}
+  m_GameObject: {fileID: 2957183606304197323}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c693660466f7ac04ea8cbdde54a5deba, type: 3}
@@ -541,7 +712,7 @@ MonoBehaviour:
   isColliding: 0
   tagsToCheck:
   - Player
---- !u!1 &771548697458528318
+--- !u!1 &2957183606371556816
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -549,38 +720,37 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 771548697458528305}
-  - component: {fileID: 771548697458528307}
-  - component: {fileID: 771548697458528304}
+  - component: {fileID: 2957183606371556817}
+  - component: {fileID: 2957183606371556830}
   m_Layer: 0
-  m_Name: StillMoreToWalkCheck
+  m_Name: GroupAlertCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &771548697458528305
+--- !u!4 &2957183606371556817
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771548697458528318}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.35, y: -0.23118567, z: 0}
+  m_GameObject: {fileID: 2957183606371556816}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 771548696854713196}
-  m_RootOrder: 5
+  m_Father: {fileID: 2957183605891938225}
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!58 &771548697458528307
-CircleCollider2D:
+--- !u!61 &2957183606371556830
+BoxCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771548697458528318}
+  m_GameObject: {fileID: 2957183606371556816}
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
@@ -588,70 +758,6 @@ CircleCollider2D:
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 0.05
---- !u!114 &771548697458528304
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771548697458528318}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 661ac1d486f89174f9d7d43fd300f07e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  isColliding: 0
-  tagsToCheck:
-  - Ground
---- !u!1 &771548697724702993
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 771548697724702992}
-  - component: {fileID: 771548697724702994}
-  - component: {fileID: 771548697724702995}
-  m_Layer: 0
-  m_Name: Box Collider 1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &771548697724702992
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771548697724702993}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 771548696423926448}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!61 &771548697724702994
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771548697724702993}
-  m_Enabled: 0
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: -0.38146353, y: 0.10137996}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0, y: 0}
@@ -662,24 +768,9 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 0.36766434, y: 0.40546674}
+  m_Size: {x: 4, y: 1}
   m_EdgeRadius: 0
---- !u!114 &771548697724702995
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771548697724702993}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3866054b6ecb4fc41967a9a27ad200d3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  isColliding: 0
-  tagsToCheck:
-  - Player
---- !u!1 &771548698097287245
+--- !u!1 &4812378990504270876
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -687,147 +778,9 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 771548698097287244}
-  - component: {fileID: 771548698097287246}
-  - component: {fileID: 771548698097287247}
-  m_Layer: 0
-  m_Name: JumpBackGroundCheck
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &771548698097287244
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771548698097287245}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -1.45, y: -0.23118567, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 771548696854713196}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!58 &771548698097287246
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771548698097287245}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 0.05
---- !u!114 &771548698097287247
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771548698097287245}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 661ac1d486f89174f9d7d43fd300f07e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  isColliding: 0
-  tagsToCheck:
-  - Ground
---- !u!1 &771548698115832068
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 771548698115832071}
-  - component: {fileID: 771548698115832121}
-  - component: {fileID: 771548698115832070}
-  m_Layer: 0
-  m_Name: Box Collider 2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &771548698115832071
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771548698115832068}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 771548696423926448}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!61 &771548698115832121
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771548698115832068}
-  m_Enabled: 0
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0.11340809, y: 0.23884419}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 0.6357193, y: 0.1374113}
-  m_EdgeRadius: 0
---- !u!114 &771548698115832070
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771548698115832068}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3866054b6ecb4fc41967a9a27ad200d3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  isColliding: 0
-  tagsToCheck:
-  - Player
---- !u!1 &2964961801301530751
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 360719255234833964}
-  - component: {fileID: 6594326574005602299}
-  - component: {fileID: 4165576921009657912}
+  - component: {fileID: 1307318236807199043}
+  - component: {fileID: 252801715521905154}
+  - component: {fileID: 1360207064569781344}
   m_Layer: 1
   m_Name: SmokeGround
   m_TagString: Untagged
@@ -835,28 +788,28 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &360719255234833964
+--- !u!4 &1307318236807199043
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2964961801301530751}
+  m_GameObject: {fileID: 4812378990504270876}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: -0.168, z: 0}
+  m_LocalPosition: {x: 0, y: -0.181, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 771548696854713196}
+  m_Father: {fileID: 2957183605891938225}
   m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!198 &6594326574005602299
+--- !u!198 &252801715521905154
 ParticleSystem:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2964961801301530751}
+  m_GameObject: {fileID: 4812378990504270876}
   serializedVersion: 8
   lengthInSec: 1
   simulationSpeed: 1
@@ -5627,14 +5580,14 @@ ParticleSystem:
         m_PostInfinity: 2
         m_RotationOrder: 4
     vectorLabel1_3: W
---- !u!199 &4165576921009657912
+--- !u!199 &1360207064569781344
 ParticleSystemRenderer:
   serializedVersion: 6
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2964961801301530751}
+  m_GameObject: {fileID: 4812378990504270876}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -5699,7 +5652,7 @@ ParticleSystemRenderer:
   m_MeshWeighting2: 1
   m_MeshWeighting3: 1
   m_MaskInteraction: 0
---- !u!1 &6017575530844855003
+--- !u!1 &6341447610337184127
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -5707,73 +5660,9 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 4644685787510159637}
-  - component: {fileID: 4563629694082699764}
-  - component: {fileID: 8920816655398638726}
-  m_Layer: 0
-  m_Name: WalkAwayCheck
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &4644685787510159637
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6017575530844855003}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.35, y: -0.23118567, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 771548696854713196}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!58 &4563629694082699764
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6017575530844855003}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 0.05
---- !u!114 &8920816655398638726
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6017575530844855003}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 661ac1d486f89174f9d7d43fd300f07e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  isColliding: 0
-  tagsToCheck:
-  - Ground
---- !u!1 &8823406254731633115
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1334871721644376303}
-  - component: {fileID: 5119220144170851674}
-  - component: {fileID: 946444663622832027}
+  - component: {fileID: 4975512656714291628}
+  - component: {fileID: 932740076738071800}
+  - component: {fileID: 5476514084401408926}
   m_Layer: 1
   m_Name: SmokeTrail
   m_TagString: Untagged
@@ -5781,28 +5670,28 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1334871721644376303
+--- !u!4 &4975512656714291628
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8823406254731633115}
+  m_GameObject: {fileID: 6341447610337184127}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: -0.218, z: 0}
+  m_LocalPosition: {x: 0, y: -0.231, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 771548696854713196}
+  m_Father: {fileID: 2957183605891938225}
   m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!198 &5119220144170851674
+--- !u!198 &932740076738071800
 ParticleSystem:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8823406254731633115}
+  m_GameObject: {fileID: 6341447610337184127}
   serializedVersion: 8
   lengthInSec: 0.15
   simulationSpeed: 1
@@ -10515,14 +10404,14 @@ ParticleSystem:
         m_PostInfinity: 2
         m_RotationOrder: 4
     vectorLabel1_3: W
---- !u!199 &946444663622832027
+--- !u!199 &5476514084401408926
 ParticleSystemRenderer:
   serializedVersion: 6
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8823406254731633115}
+  m_GameObject: {fileID: 6341447610337184127}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0

--- a/Assets/Prefabs/Characters/Enemies/Archer/Forest Ranger - No Jump.prefab.meta
+++ b/Assets/Prefabs/Characters/Enemies/Archer/Forest Ranger - No Jump.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1e4465317b95a7a4c8163d8c504c2541
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Characters/Enemies/Archer/Forest Ranger.prefab
+++ b/Assets/Prefabs/Characters/Enemies/Archer/Forest Ranger.prefab
@@ -75,7 +75,7 @@ GameObject:
   - component: {fileID: 2957183604744304406}
   - component: {fileID: 2957183604744304404}
   - component: {fileID: 2957183604744304407}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: AttackZoneCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -276,7 +276,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2957183605755421289}
   - component: {fileID: 2957183605755421270}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: VisionFieldCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -497,8 +497,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   attackZoneCollider: {fileID: 2957183604744304407}
   dangerZoneCollider: {fileID: 2957183606304197321}
-  stillMoreToWalkCheck: {fileID: 2957183605671449914}
-  jumpBackGroundCheck: {fileID: 2957183606066013608}
   startleDuration: 1
 --- !u!114 &2957183605891938237
 MonoBehaviour:
@@ -651,7 +649,7 @@ GameObject:
   - component: {fileID: 2957183606304197320}
   - component: {fileID: 2957183606304197302}
   - component: {fileID: 2957183606304197321}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: DangerZoneCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -724,7 +722,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2957183606371556817}
   - component: {fileID: 2957183606371556830}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: GroupAlertCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Prefabs/Characters/Enemies/Swordsman/Heavy Bandit.prefab
+++ b/Assets/Prefabs/Characters/Enemies/Swordsman/Heavy Bandit.prefab
@@ -4930,7 +4930,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6143442377562652871}
   - component: {fileID: 6143442377562652865}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: VisionFieldCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4989,7 +4989,7 @@ GameObject:
   - component: {fileID: 6143442378142866448}
   - component: {fileID: 6143442378142866450}
   - component: {fileID: 6143442378142866449}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: AttackZoneCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5225,6 +5225,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   attackZoneCollider: {fileID: 6143442378142866449}
   startleDuration: 0.5
+  attackDelay: 0.1
 --- !u!114 &6143442378185450499
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5515,7 +5516,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6914418752066569005}
   - component: {fileID: 6914418752066569004}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: GroupAlertCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Prefabs/Characters/Enemies/Swordsman/Knight.prefab
+++ b/Assets/Prefabs/Characters/Enemies/Swordsman/Knight.prefab
@@ -10235,7 +10235,7 @@ GameObject:
   - component: {fileID: 8428708079665638834}
   - component: {fileID: 8428708079665638832}
   - component: {fileID: 8428708079665638835}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: AttackZoneCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -10308,7 +10308,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8428708080137679205}
   - component: {fileID: 8428708080137679203}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: VisionFieldCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -10462,7 +10462,7 @@ GameObject:
   m_Component:
   - component: {fileID: 9101174672306500239}
   - component: {fileID: 9101174672306500238}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: GroupAlertCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Prefabs/Characters/Enemies/Swordsman/Light Bandit.prefab
+++ b/Assets/Prefabs/Characters/Enemies/Swordsman/Light Bandit.prefab
@@ -4892,7 +4892,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3644736829981722950}
   - component: {fileID: 3644736829981722944}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: VisionFieldCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4983,7 +4983,7 @@ GameObject:
   - component: {fileID: 3644736830490105233}
   - component: {fileID: 3644736830490105235}
   - component: {fileID: 3644736830490105232}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: AttackZoneCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5219,6 +5219,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   attackZoneCollider: {fileID: 3644736830490105232}
   startleDuration: 1
+  attackDelay: 0.1
 --- !u!114 &3644736830735068546
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5573,7 +5574,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4044693872093579948}
   - component: {fileID: 4044693872093579949}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: GroupAlertCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Prefabs/Characters/Enemies/Swordsman/Samurai.prefab
+++ b/Assets/Prefabs/Characters/Enemies/Swordsman/Samurai.prefab
@@ -10034,7 +10034,7 @@ GameObject:
   - component: {fileID: 7210463735612525738}
   - component: {fileID: 7210463735612525736}
   - component: {fileID: 7210463735612525739}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: AttackZoneCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -10107,7 +10107,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7210463736114974845}
   - component: {fileID: 7210463736114974843}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: VisionFieldCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -10464,7 +10464,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7972956712555926423}
   - component: {fileID: 7972956712555926422}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: GroupAlertCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Prefabs/Characters/Enemies/Swordsman/Silver Knight.prefab
+++ b/Assets/Prefabs/Characters/Enemies/Swordsman/Silver Knight.prefab
@@ -9780,7 +9780,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7412544364781323673}
   - component: {fileID: 7412544364781323679}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: VisionFieldCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -9872,7 +9872,7 @@ GameObject:
   - component: {fileID: 7412544365364517198}
   - component: {fileID: 7412544365364517196}
   - component: {fileID: 7412544365364517199}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: AttackZoneCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -10464,7 +10464,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7812534379356554867}
   - component: {fileID: 7812534379356554866}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: GroupAlertCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Prefabs/Characters/Enemies/Swordsman/Urokodaki.prefab
+++ b/Assets/Prefabs/Characters/Enemies/Swordsman/Urokodaki.prefab
@@ -10310,7 +10310,7 @@ GameObject:
   - component: {fileID: 8116333819402978350}
   - component: {fileID: 8116333819402978348}
   - component: {fileID: 8116333819402978351}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: AttackZoneCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -10383,7 +10383,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8116333820006652153}
   - component: {fileID: 8116333820006652159}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: VisionFieldCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -10474,7 +10474,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8797243012157676307}
   - component: {fileID: 8797243012157676306}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: GroupAlertCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Prefabs/Characters/Enemies/Wizard/Bolt Wizard - Short Range.prefab
+++ b/Assets/Prefabs/Characters/Enemies/Wizard/Bolt Wizard - Short Range.prefab
@@ -5081,7 +5081,7 @@ MonoBehaviour:
   meleeAttackAnimationClip: {fileID: 7400000, guid: 01f2abc34cc43554bb1f1e1a0dcfe1e7, type: 2}
   attackCooldownDuration: 3
   magicProjectilePrefab: {fileID: 5039259422374071178, guid: cd2bfd63f1cdb0a42856c944bfd04584, type: 3}
-  shootingForce: 1.5
+  shootingForce: 3
   shootingWaitingTime: 0.5
 --- !u!114 &8742912997571526416
 MonoBehaviour:
@@ -5218,7 +5218,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8742912997975740133}
   - component: {fileID: 8742912997975740132}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: GroupAlertCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5277,7 +5277,7 @@ GameObject:
   - component: {fileID: 8742912998008352730}
   - component: {fileID: 8742912998008352708}
   - component: {fileID: 8742912998008352731}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: AttackZoneCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5415,7 +5415,7 @@ GameObject:
   - component: {fileID: 8742912998069901048}
   - component: {fileID: 8742912998069901050}
   - component: {fileID: 8742912998069901049}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: DangerZoneCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5489,7 +5489,7 @@ GameObject:
   - component: {fileID: 8742912998079876962}
   - component: {fileID: 8742912998079876961}
   - component: {fileID: 8742912998079876960}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: MeleeZoneCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -10445,7 +10445,7 @@ GameObject:
   - component: {fileID: 8742912998456251003}
   - component: {fileID: 8742912998456250981}
   - component: {fileID: 8742912998456250980}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: Wand - MeeleMagic
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -10572,7 +10572,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8742912998858236833}
   - component: {fileID: 8742912998858236832}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: VisionFieldCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Prefabs/Characters/Enemies/Wizard/Bolt Wizard.prefab
+++ b/Assets/Prefabs/Characters/Enemies/Wizard/Bolt Wizard.prefab
@@ -5081,7 +5081,7 @@ MonoBehaviour:
   meleeAttackAnimationClip: {fileID: 7400000, guid: 01f2abc34cc43554bb1f1e1a0dcfe1e7, type: 2}
   attackCooldownDuration: 3
   magicProjectilePrefab: {fileID: 5039259422374071178, guid: cd2bfd63f1cdb0a42856c944bfd04584, type: 3}
-  shootingForce: 1.5
+  shootingForce: 3
   shootingWaitingTime: 0.5
 --- !u!114 &8742912997571526416
 MonoBehaviour:
@@ -5218,7 +5218,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8742912997975740133}
   - component: {fileID: 8742912997975740132}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: GroupAlertCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5277,7 +5277,7 @@ GameObject:
   - component: {fileID: 8742912998008352730}
   - component: {fileID: 8742912998008352708}
   - component: {fileID: 8742912998008352731}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: AttackZoneCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5415,7 +5415,7 @@ GameObject:
   - component: {fileID: 8742912998069901048}
   - component: {fileID: 8742912998069901050}
   - component: {fileID: 8742912998069901049}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: DangerZoneCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5489,7 +5489,7 @@ GameObject:
   - component: {fileID: 8742912998079876962}
   - component: {fileID: 8742912998079876961}
   - component: {fileID: 8742912998079876960}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: MeleeZoneCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -10445,7 +10445,7 @@ GameObject:
   - component: {fileID: 8742912998456251003}
   - component: {fileID: 8742912998456250981}
   - component: {fileID: 8742912998456250980}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: Wand - MeeleMagic
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -10572,7 +10572,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8742912998858236833}
   - component: {fileID: 8742912998858236832}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: VisionFieldCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Prefabs/Characters/Enemies/Wizard/Dark Wizard.prefab
+++ b/Assets/Prefabs/Characters/Enemies/Wizard/Dark Wizard.prefab
@@ -257,7 +257,7 @@ MonoBehaviour:
   meleeAttackAnimationClip: {fileID: 7400000, guid: 7bf21a54ee4fba649952e9d3433e6c54, type: 2}
   attackCooldownDuration: 3
   magicProjectilePrefab: {fileID: 1823809230247134057, guid: 7f3885e971a0e154f8a00f8496db6582, type: 3}
-  shootingForce: 1.5
+  shootingForce: 3
   shootingWaitingTime: 0.5
 --- !u!114 &8697647331725521208
 MonoBehaviour:
@@ -459,7 +459,7 @@ GameObject:
   - component: {fileID: 8697647332093862386}
   - component: {fileID: 8697647332093862380}
   - component: {fileID: 8697647332093862387}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: AttackZoneCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -532,7 +532,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8697647332126589133}
   - component: {fileID: 8697647332126589132}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: GroupAlertCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5478,7 +5478,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8697647332854721929}
   - component: {fileID: 8697647332854721928}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: VisionFieldCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -10419,7 +10419,7 @@ GameObject:
   - component: {fileID: 8697647333373958352}
   - component: {fileID: 8697647333373958354}
   - component: {fileID: 8697647333373958353}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: DangerZoneCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -10493,7 +10493,7 @@ GameObject:
   - component: {fileID: 8697647333380751690}
   - component: {fileID: 8697647333380751689}
   - component: {fileID: 8697647333380751688}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: MeleeZoneCollider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -10567,7 +10567,7 @@ GameObject:
   - component: {fileID: 8697647333524610131}
   - component: {fileID: 8697647333524610129}
   - component: {fileID: 8697647333524610128}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: Wand - MeeleMagic
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Prefabs/Characters/Enemies/Wizard/Fire Wizard.prefab
+++ b/Assets/Prefabs/Characters/Enemies/Wizard/Fire Wizard.prefab
@@ -10371,7 +10371,7 @@ MonoBehaviour:
   meleeAttackAnimationClip: {fileID: 7400000, guid: 7bf21a54ee4fba649952e9d3433e6c54, type: 2}
   attackCooldownDuration: 3
   magicProjectilePrefab: {fileID: 5339643554312622404, guid: 57395e93b55b8274c98c6435061b5bfc, type: 3}
-  shootingForce: 1.5
+  shootingForce: 3
   shootingWaitingTime: 0.2
 --- !u!114 &3403554590150775901
 MonoBehaviour:

--- a/Assets/Prefabs/Map/Blocks/Earthy Block.prefab
+++ b/Assets/Prefabs/Map/Blocks/Earthy Block.prefab
@@ -72,7 +72,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -486472081
-  m_SortingLayer: 5
+  m_SortingLayer: 6
   m_SortingOrder: 0
   m_Sprite: {fileID: -2058987948, guid: 888a6673aef3c8249867ef5a48ea83d5, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -94,7 +94,7 @@ PolygonCollider2D:
   m_GameObject: {fileID: 3869175445727238960}
   m_Enabled: 1
   m_Density: 1
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 6200000, guid: 18512d9c28574ca4f9157986b58aa5a8, type: 2}
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0

--- a/Assets/Prefabs/Map/Blocks/Earthy Grassy Block - Big.prefab
+++ b/Assets/Prefabs/Map/Blocks/Earthy Grassy Block - Big.prefab
@@ -72,7 +72,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -486472081
-  m_SortingLayer: 5
+  m_SortingLayer: 6
   m_SortingOrder: 0
   m_Sprite: {fileID: -423233016, guid: 888a6673aef3c8249867ef5a48ea83d5, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -94,7 +94,7 @@ PolygonCollider2D:
   m_GameObject: {fileID: 7838359911046812200}
   m_Enabled: 1
   m_Density: 1
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 6200000, guid: 18512d9c28574ca4f9157986b58aa5a8, type: 2}
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0

--- a/Assets/Prefabs/Map/Blocks/Stone Block - Medium.prefab
+++ b/Assets/Prefabs/Map/Blocks/Stone Block - Medium.prefab
@@ -94,7 +94,7 @@ PolygonCollider2D:
   m_GameObject: {fileID: 5222524543507999362}
   m_Enabled: 1
   m_Density: 1
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 6200000, guid: 18512d9c28574ca4f9157986b58aa5a8, type: 2}
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0

--- a/Assets/Prefabs/Map/Blocks/Stone Block - Small.prefab
+++ b/Assets/Prefabs/Map/Blocks/Stone Block - Small.prefab
@@ -94,7 +94,7 @@ PolygonCollider2D:
   m_GameObject: {fileID: 9017593654189137781}
   m_Enabled: 1
   m_Density: 1
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 6200000, guid: 18512d9c28574ca4f9157986b58aa5a8, type: 2}
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -579,7 +579,7 @@ PolygonCollider2D:
   m_GameObject: {fileID: 134752275}
   m_Enabled: 1
   m_Density: 1
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 6200000, guid: 18512d9c28574ca4f9157986b58aa5a8, type: 2}
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
@@ -597,24 +597,24 @@ PolygonCollider2D:
     m_Paths:
     - - {x: -0.6810295, y: 1.7172885}
       - {x: -2.5148113, y: 1.7117584}
-      - {x: -3.3123565, y: 1.7525939}
-      - {x: -3.600803, y: 1.7341443}
+      - {x: -3.4507892, y: 1.7141403}
+      - {x: -3.6084936, y: 1.7110722}
       - {x: -3.5730004, y: 1.5745418}
       - {x: -3.5030544, y: 1.5133265}
-      - {x: -3.478318, y: 0.97610295}
-      - {x: -4.455848, y: 0.9828894}
+      - {x: -3.4664173, y: 0.95230186}
+      - {x: -4.473699, y: 0.94718766}
       - {x: -4.6991205, y: 0.9092741}
       - {x: -4.6916924, y: 0.8074244}
       - {x: -4.6232305, y: 0.73726416}
       - {x: -4.5545516, y: 0.7115474}
-      - {x: -4.541076, y: 0.15340376}
+      - {x: -4.558927, y: 0.12960243}
       - {x: -5.58336, y: 0.1358751}
       - {x: -5.8335724, y: 0.11762428}
       - {x: -5.8110795, y: 0.00647521}
       - {x: -5.74289, y: -0.0848515}
       - {x: -5.706486, y: -0.08411026}
       - {x: -5.686389, y: -0.66057754}
-      - {x: -6.708839, y: -0.6274817}
+      - {x: -6.7326403, y: -0.6691339}
       - {x: -6.95654, y: -0.7012017}
       - {x: -6.941294, y: -0.81371474}
       - {x: -6.848481, y: -0.88700247}
@@ -653,7 +653,7 @@ PolygonCollider2D:
       - {x: 2.1967566, y: 1.5817565}
       - {x: 2.2528932, y: 1.6048595}
       - {x: 2.239309, y: 1.6981575}
-      - {x: 1.9929149, y: 1.7637086}
+      - {x: 2.0104678, y: 1.7373794}
 --- !u!1 &167333841
 GameObject:
   m_ObjectHideFlags: 0
@@ -37020,7 +37020,7 @@ PolygonCollider2D:
   m_GameObject: {fileID: 1473959344}
   m_Enabled: 1
   m_Density: 1
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 6200000, guid: 18512d9c28574ca4f9157986b58aa5a8, type: 2}
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
@@ -37211,7 +37211,7 @@ PolygonCollider2D:
   m_GameObject: {fileID: 1563937881}
   m_Enabled: 1
   m_Density: 1
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 6200000, guid: 18512d9c28574ca4f9157986b58aa5a8, type: 2}
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
@@ -37884,6 +37884,14 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1853539560}
     m_Modifications:
+    - target: {fileID: 1971838360380672435, guid: da2b955bb7d5a7c43a29028653e8dd83, type: 3}
+      propertyPath: maxHitPoints
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1971838360380672435, guid: da2b955bb7d5a7c43a29028653e8dd83, type: 3}
+      propertyPath: currentHitPoints
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4697750405587687972, guid: da2b955bb7d5a7c43a29028653e8dd83, type: 3}
       propertyPath: m_RootOrder
       value: 2

--- a/Assets/Scenes/Route 1.unity
+++ b/Assets/Scenes/Route 1.unity
@@ -4041,22 +4041,6 @@ Tilemap:
     e31: 0
     e32: 0
     e33: 1
---- !u!4 &64774561 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 6040917913547949045, guid: 1296094cee6366740b7f9a067805457e, type: 3}
-  m_PrefabInstance: {fileID: 1806104719}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &64774562 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6040917913547949046, guid: 1296094cee6366740b7f9a067805457e, type: 3}
-  m_PrefabInstance: {fileID: 1806104719}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7950469238412a142984eeeb0aebc751, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &68632773
 GameObject:
   m_ObjectHideFlags: 0
@@ -7451,7 +7435,6 @@ Transform:
   - {fileID: 1649463537}
   - {fileID: 1032412370}
   - {fileID: 662573912}
-  - {fileID: 64774561}
   m_Father: {fileID: 2071746090}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -7517,7 +7500,7 @@ PrefabInstance:
     - target: {fileID: 6040917913547949046, guid: 1296094cee6366740b7f9a067805457e, type: 3}
       propertyPath: possibleEnemies.Array.data[0]
       value: 
-      objectReference: {fileID: 2957183605891938226, guid: b51da8133876644468de399ec6a8242b, type: 3}
+      objectReference: {fileID: 2957183605891938226, guid: 1e4465317b95a7a4c8163d8c504c2541, type: 3}
     - target: {fileID: 6040917913547949047, guid: 1296094cee6366740b7f9a067805457e, type: 3}
       propertyPath: m_Name
       value: Spawner 3
@@ -21893,7 +21876,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 27
-      m_TileSpriteIndex: 27
+      m_TileSpriteIndex: 38
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -21903,7 +21886,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 28
-      m_TileSpriteIndex: 28
+      m_TileSpriteIndex: 37
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -22023,7 +22006,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 4
-      m_TileSpriteIndex: 3
+      m_TileSpriteIndex: 36
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -22123,7 +22106,7 @@ Tilemap:
     second:
       serializedVersion: 2
       m_TileIndex: 29
-      m_TileSpriteIndex: 29
+      m_TileSpriteIndex: 35
       m_TileMatrixIndex: 0
       m_TileColorIndex: 0
       m_TileObjectToInstantiateIndex: 65535
@@ -22660,8 +22643,8 @@ Tilemap:
     m_Data: {fileID: 1705935416, guid: 888a6673aef3c8249867ef5a48ea83d5, type: 3}
   - m_RefCount: 8
     m_Data: {fileID: 1681418539, guid: 888a6673aef3c8249867ef5a48ea83d5, type: 3}
-  - m_RefCount: 1
-    m_Data: {fileID: 1775321676, guid: 888a6673aef3c8249867ef5a48ea83d5, type: 3}
+  - m_RefCount: 0
+    m_Data: {fileID: 0}
   - m_RefCount: 8
     m_Data: {fileID: 426019292, guid: 888a6673aef3c8249867ef5a48ea83d5, type: 3}
   - m_RefCount: 2
@@ -22708,12 +22691,12 @@ Tilemap:
     m_Data: {fileID: 1235642543, guid: 888a6673aef3c8249867ef5a48ea83d5, type: 3}
   - m_RefCount: 2
     m_Data: {fileID: -278502624, guid: 888a6673aef3c8249867ef5a48ea83d5, type: 3}
-  - m_RefCount: 1
-    m_Data: {fileID: 1214570791, guid: 888a6673aef3c8249867ef5a48ea83d5, type: 3}
-  - m_RefCount: 1
-    m_Data: {fileID: 93932697, guid: 888a6673aef3c8249867ef5a48ea83d5, type: 3}
-  - m_RefCount: 1
-    m_Data: {fileID: 314535886, guid: 888a6673aef3c8249867ef5a48ea83d5, type: 3}
+  - m_RefCount: 0
+    m_Data: {fileID: 0}
+  - m_RefCount: 0
+    m_Data: {fileID: 0}
+  - m_RefCount: 0
+    m_Data: {fileID: 0}
   - m_RefCount: 1
     m_Data: {fileID: 1108014379, guid: 888a6673aef3c8249867ef5a48ea83d5, type: 3}
   - m_RefCount: 3
@@ -22724,14 +22707,14 @@ Tilemap:
     m_Data: {fileID: 1329501465, guid: 888a6673aef3c8249867ef5a48ea83d5, type: 3}
   - m_RefCount: 5
     m_Data: {fileID: 1873294146, guid: 888a6673aef3c8249867ef5a48ea83d5, type: 3}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
+  - m_RefCount: 1
+    m_Data: {fileID: 314535886, guid: 888a6673aef3c8249867ef5a48ea83d5, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 1775321676, guid: 888a6673aef3c8249867ef5a48ea83d5, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 93932697, guid: 888a6673aef3c8249867ef5a48ea83d5, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 1214570791, guid: 888a6673aef3c8249867ef5a48ea83d5, type: 3}
   - m_RefCount: 1
     m_Data: {fileID: 1568275034, guid: 888a6673aef3c8249867ef5a48ea83d5, type: 3}
   - m_RefCount: 1
@@ -30448,7 +30431,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6040917913547949045, guid: 1296094cee6366740b7f9a067805457e, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 8.425
+      value: 8.18
       objectReference: {fileID: 0}
     - target: {fileID: 6040917913547949045, guid: 1296094cee6366740b7f9a067805457e, type: 3}
       propertyPath: m_LocalPosition.y
@@ -42816,7 +42799,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1121704464}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.82909584, y: 42.640907, z: -5}
+  m_LocalPosition: {x: 1.0199995, y: 55.059998, z: -5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -50551,7 +50534,7 @@ PrefabInstance:
     - target: {fileID: 6040917913547949046, guid: 1296094cee6366740b7f9a067805457e, type: 3}
       propertyPath: possibleEnemies.Array.data[0]
       value: 
-      objectReference: {fileID: 2957183605891938226, guid: b51da8133876644468de399ec6a8242b, type: 3}
+      objectReference: {fileID: 2957183605891938226, guid: 1e4465317b95a7a4c8163d8c504c2541, type: 3}
     - target: {fileID: 6040917913547949047, guid: 1296094cee6366740b7f9a067805457e, type: 3}
       propertyPath: m_Name
       value: Spawner 4
@@ -51281,7 +51264,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6040917913547949045, guid: 1296094cee6366740b7f9a067805457e, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 8.753
+      value: 8.507999
       objectReference: {fileID: 0}
     - target: {fileID: 6040917913547949045, guid: 1296094cee6366740b7f9a067805457e, type: 3}
       propertyPath: m_LocalPosition.y
@@ -56714,75 +56697,6 @@ Transform:
   m_Father: {fileID: 1403479522}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1806104719
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 207998280}
-    m_Modifications:
-    - target: {fileID: 6040917913547949045, guid: 1296094cee6366740b7f9a067805457e, type: 3}
-      propertyPath: m_RootOrder
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 6040917913547949045, guid: 1296094cee6366740b7f9a067805457e, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 9.006
-      objectReference: {fileID: 0}
-    - target: {fileID: 6040917913547949045, guid: 1296094cee6366740b7f9a067805457e, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 3.363
-      objectReference: {fileID: 0}
-    - target: {fileID: 6040917913547949045, guid: 1296094cee6366740b7f9a067805457e, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.002420719
-      objectReference: {fileID: 0}
-    - target: {fileID: 6040917913547949045, guid: 1296094cee6366740b7f9a067805457e, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6040917913547949045, guid: 1296094cee6366740b7f9a067805457e, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6040917913547949045, guid: 1296094cee6366740b7f9a067805457e, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6040917913547949045, guid: 1296094cee6366740b7f9a067805457e, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6040917913547949045, guid: 1296094cee6366740b7f9a067805457e, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6040917913547949045, guid: 1296094cee6366740b7f9a067805457e, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6040917913547949045, guid: 1296094cee6366740b7f9a067805457e, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6040917913547949046, guid: 1296094cee6366740b7f9a067805457e, type: 3}
-      propertyPath: facingRight
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6040917913547949046, guid: 1296094cee6366740b7f9a067805457e, type: 3}
-      propertyPath: possibleEnemies.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6040917913547949046, guid: 1296094cee6366740b7f9a067805457e, type: 3}
-      propertyPath: possibleEnemies.Array.data[0]
-      value: 
-      objectReference: {fileID: 771548696854713193, guid: d6488a535dbde8843a297c3fe7bd5c75, type: 3}
-    - target: {fileID: 6040917913547949047, guid: 1296094cee6366740b7f9a067805457e, type: 3}
-      propertyPath: m_Name
-      value: Spawner 7
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 1296094cee6366740b7f9a067805457e, type: 3}
 --- !u!1 &1809552555
 GameObject:
   m_ObjectHideFlags: 0
@@ -78755,7 +78669,6 @@ MonoBehaviour:
   - {fileID: 1649463538}
   - {fileID: 1032412371}
   - {fileID: 662573913}
-  - {fileID: 64774562}
   frameChangeTrigger: {fileID: 1571100133}
   playerSpawnPoint: {fileID: 297632410}
 --- !u!1 &2085150334

--- a/Assets/Scripts/Animations/CinemachineTransition.cs
+++ b/Assets/Scripts/Animations/CinemachineTransition.cs
@@ -12,9 +12,30 @@ public class CinemachineTransition : MonoBehaviour
 
     [SerializeField] BoxCollider2D blockCollider;
 
+    private GameObject player;
+
     private void Awake()
     {
         transitionTrigger = GetComponent<BoxCollider>();
+    }
+
+    private void Start()
+    {
+        player = GameManager.instance.GetPlayer();
+    }
+
+    private void Update()
+    {
+        if (!player.GetComponent<DamageReceiver>().IsAlive)
+        {
+            if (Input.GetKeyDown(KeyCode.Space) && !GameManager.instance.IsTeleporting())
+            {
+                activeVcam.Priority = 1;
+                otherVcam.Priority = 0;
+
+                blockCollider.gameObject.SetActive(false);
+            }
+        }
     }
 
     private void FixedUpdate()
@@ -25,8 +46,6 @@ public class CinemachineTransition : MonoBehaviour
             otherVcam.Priority = 1;
 
             blockCollider.gameObject.SetActive(true);
-
-            Destroy(gameObject);
         }
     }
 }

--- a/Assets/Scripts/Characters/Enemies/Archer/ArcherAttacks.cs
+++ b/Assets/Scripts/Characters/Enemies/Archer/ArcherAttacks.cs
@@ -26,11 +26,13 @@ public class ArcherAttacks : MonoBehaviour
 
     [SerializeField] private Arrow arrowPrefab;
 
-    private float[] shootingSpeeds = { 7f, 10f, 12f };
+    private float[] shootingSpeeds = { 10f, 7f };
     private float shootingSpeed;
     private float shootingAngle;
     private Vector2 shootingDirection;
     private bool isGoingToShoot = false;
+
+    private GameObject projectileContainer;
 
     private void Awake()
     {
@@ -40,6 +42,8 @@ public class ArcherAttacks : MonoBehaviour
     private void Start()
     {
         GetComponent<DamageReceiver>().OnCharacterAliveStatusChange += Death;
+
+        projectileContainer = GameObject.FindGameObjectWithTag("Projectile Container");
     }
 
     public void ArrowAttack(Vector3 archerPosition, Vector3 playerPosition)
@@ -159,6 +163,7 @@ public class ArcherAttacks : MonoBehaviour
         yield return new WaitForSeconds(.3f);
 
         Arrow newArrow = Instantiate(arrowPrefab, transform.position + new Vector3(transform.localScale.x * .16f, 0, 0), Quaternion.identity);
+        newArrow.transform.SetParent(projectileContainer.transform);
 
         if (transform.localScale.x < 0)
         {

--- a/Assets/Scripts/Characters/Enemies/PlayerDetection.cs
+++ b/Assets/Scripts/Characters/Enemies/PlayerDetection.cs
@@ -66,7 +66,8 @@ public class PlayerDetection : MonoBehaviour
         {
             foreach (RaycastHit2D enemy in enemyGroup)
             {
-                enemy.transform.gameObject.GetComponent<PlayerDetection>().DetectedPlayer = true;
+                if (enemy.transform.gameObject.GetComponent<DamageReceiver>().IsAlive)
+                    enemy.transform.gameObject.GetComponent<PlayerDetection>().DetectedPlayer = true;
             }
         }
 

--- a/Assets/Scripts/Characters/Enemies/Wizard/WizardAttacks.cs
+++ b/Assets/Scripts/Characters/Enemies/Wizard/WizardAttacks.cs
@@ -54,7 +54,7 @@ public class WizardAttacks : MonoBehaviour
         float xDistance = playerPosition.x - magePosition.x;
         float yDistance = playerPosition.y - magePosition.y;
 
-        Vector2 shootingDirection = new Vector2(xDistance, yDistance);
+        Vector2 shootingDirection = new Vector2(xDistance, yDistance).normalized;
 
         isAttacking = true;
 
@@ -69,7 +69,7 @@ public class WizardAttacks : MonoBehaviour
     {
         yield return new WaitForSeconds(shootingWaitingTime);
 
-        MagicProjectile newProjectile = Instantiate(magicProjectilePrefab, transform.position + new Vector3(transform.localScale.x * .16f, 0, 0), Quaternion.identity);
+        MagicProjectile newProjectile = Instantiate(magicProjectilePrefab, transform.position + new Vector3(transform.localScale.x * .16f, .1f, 0), Quaternion.identity);
 
         if (transform.localScale.x < 0)
         {

--- a/Assets/Scripts/Characters/Mover.cs
+++ b/Assets/Scripts/Characters/Mover.cs
@@ -133,7 +133,7 @@ public class Mover : MonoBehaviour
                 }
             }
             
-            if (isCollidingWithWall && !isGrounded && !isWallSliding)
+            if (hasAbilityToWallJump && isCollidingWithWall && !isGrounded && !isWallSliding)
             {
                 if (Mathf.Abs(rigidBody.velocity.x) > 0.1)
                 {

--- a/Assets/Scripts/Characters/Player/PlayerAttackController.cs
+++ b/Assets/Scripts/Characters/Player/PlayerAttackController.cs
@@ -52,14 +52,14 @@ public class PlayerAttackController : MonoBehaviour
             playerMovementController.FinishWallSliding();
             StartCoroutine(CooldownToMove());
         }
-            
 
+        StartCoroutine(IsAttackingCooldown());
         animator.SetTrigger("FirstAttack");
 
         if(!playerMovementController.IsJumping())
             ableToDoSecondAttack = true;
 
-        StartCoroutine(Cooldown());
+        StartCoroutine(AttackCooldown());
     }
 
     private IEnumerator DoSecondAttack()
@@ -73,7 +73,16 @@ public class PlayerAttackController : MonoBehaviour
         animator.SetBool("IsDoingSecondAttack", false);
     }
 
-    private IEnumerator Cooldown()
+    private IEnumerator IsAttackingCooldown()
+    {
+        animator.SetBool("IsAttacking", true);
+
+        yield return new WaitForSeconds(.3f);
+
+        animator.SetBool("IsAttacking", false);
+    }
+
+    private IEnumerator AttackCooldown()
     {
         yield return new WaitForSeconds(attackCooldownDuration*(0.75f));
 
@@ -81,6 +90,11 @@ public class PlayerAttackController : MonoBehaviour
 
         yield return new WaitForSeconds(attackCooldownDuration*(0.25f));
 
+        onAttackCooldown = false;
+    }
+
+    public void EndAttackCooldown()
+    {
         onAttackCooldown = false;
     }
 

--- a/Assets/Scripts/FloatingText/FloatingTextManager.cs
+++ b/Assets/Scripts/FloatingText/FloatingTextManager.cs
@@ -20,7 +20,7 @@ public class FloatingTextManager : MonoBehaviour
     {
         FloatingText floatingText = GetFloatingText();
 
-        floatingText.go.transform.localScale *= .3f;
+        
 
         floatingText.txt.text = msg;
         floatingText.txt.fontSize = fontSize;
@@ -44,6 +44,8 @@ public class FloatingTextManager : MonoBehaviour
             floatingText.go = Instantiate(textPrefab);
             floatingText.go.transform.SetParent(textContainer.transform);
             floatingText.txt = floatingText.go.GetComponent<Text>();
+
+            floatingText.go.transform.localScale *= .3f;
 
             floatingTexts.Add(floatingText);
         }

--- a/Assets/Scripts/Frames/Frame.cs
+++ b/Assets/Scripts/Frames/Frame.cs
@@ -16,9 +16,15 @@ public class Frame : MonoBehaviour
     private GameObject player;
     [SerializeField] private Transform playerSpawnPoint;
 
+    GameObject projectileContainer;
+
     private void Start()
     {
         player = GameManager.instance.GetPlayer();
+
+        projectileContainer = new GameObject("Projectile Container");
+        projectileContainer.transform.SetParent(gameObject.transform);
+        projectileContainer.tag = "Projectile Container";
     }
 
     public void StartFrame()
@@ -58,6 +64,13 @@ public class Frame : MonoBehaviour
         player.GetComponent<DamageReceiver>().Resurrect();
         player.transform.position = playerSpawnPoint.position;
 
+        StartCoroutine(SpawnEnemiesAfterWait());
+    }
+
+    private IEnumerator SpawnEnemiesAfterWait()
+    {
+        yield return new WaitForSeconds(.1f);
+
         foreach (RandomEnemySpawner randomEnemySpawner in randomEnemySpawners)
         {
             GameObject newEnemy = randomEnemySpawner.SpawnEnemy();
@@ -71,13 +84,22 @@ public class Frame : MonoBehaviour
     public void CleanFrame()
     {
         enemiesKilledCount = 0;
-        
+
         foreach (GameObject enemy in enemies)
         {
             Destroy(enemy.gameObject);
         }
 
         enemies.Clear();
+
+        if (projectileContainer)
+        {
+            Destroy(projectileContainer.gameObject);
+            projectileContainer = new GameObject("Projectile Container");
+            projectileContainer.transform.SetParent(gameObject.transform);
+            projectileContainer.tag = "Projectile Container";
+        }
+        
 
         if (enemiesKilledCount != enemiesTotalCount)
             frameChangeTrigger.gameObject.SetActive(false);
@@ -102,7 +124,10 @@ public class Frame : MonoBehaviour
 
     public bool FrameChangeTriggered()
     {
-        return frameChangeTrigger.IsColliding();
+        if (frameChangeTrigger)
+            return frameChangeTrigger.IsColliding();
+        else
+            return false;
     }
 
     public GameObject GetPlayer()

--- a/Assets/Scripts/Frames/FrameManager.cs
+++ b/Assets/Scripts/Frames/FrameManager.cs
@@ -46,6 +46,7 @@ public class FrameManager : MonoBehaviour
 
         GameManager.instance.GetPlayer().GetComponent<Rigidbody2D>().constraints = RigidbodyConstraints2D.FreezeAll;
         GameManager.instance.GetPlayer().GetComponent<Animator>().enabled = false;
+        GameManager.instance.GetPlayer().GetComponent<PlayerAttackController>().EndAttackCooldown();
 
         GameManager.instance.GetLevelLoader().CrossfadeStart();
         yield return new WaitForSeconds(Config.START_TRANSITION_DURATION);

--- a/Assets/Scripts/Projectiles/Arrow.cs
+++ b/Assets/Scripts/Projectiles/Arrow.cs
@@ -40,6 +40,9 @@ public class Arrow : MonoBehaviour
                 rigidBody.isKinematic = true;
 
                 Destroy(GetComponent<BoxDamageDealer>());
+                Destroy(GetComponent<DamageReceiver>());
+                Destroy(GetComponent<BoxCollider2D>());
+
                 GetComponent<Animator>().enabled = false;
             }
         }
@@ -48,6 +51,18 @@ public class Arrow : MonoBehaviour
     private void Death()
     {
         brokeParticles.Play();
+
         Destroy(GetComponent<BoxDamageDealer>());
+        Destroy(GetComponent<DamageReceiver>());
+        Destroy(GetComponent<BoxCollider2D>());
+
+        StartCoroutine(WaitToDestroy());
+    }
+
+    private IEnumerator WaitToDestroy()
+    {
+        yield return new WaitForSeconds(1f);
+
+        Destroy(gameObject);
     }
 }

--- a/Assets/Scripts/Projectiles/MagicProjectile.cs
+++ b/Assets/Scripts/Projectiles/MagicProjectile.cs
@@ -14,6 +14,8 @@ public class MagicProjectile : MonoBehaviour
 
     [SerializeField] private bool isDestroyable = false;
 
+    private bool hasBeenReflected = false;
+
     private void Awake()
     {
         animator = GetComponent<Animator>();
@@ -42,8 +44,10 @@ public class MagicProjectile : MonoBehaviour
     {
         if (!hasHit)
         {
-            if (swordCollisionCheck.IsColliding())
+            if (!hasBeenReflected && swordCollisionCheck.IsColliding())
             {
+                hasBeenReflected = true;
+
                 transform.localScale = new Vector3(transform.localScale.x * -1f, transform.localScale.y, transform.localScale.z);
 
                 Vector2 originalVelocity = rigidBody.velocity;

--- a/ProjectSettings/InputManager.asset
+++ b/ProjectSettings/InputManager.asset
@@ -11,8 +11,8 @@ InputManager:
     descriptiveNegativeName: 
     negativeButton: left
     positiveButton: right
-    altNegativeButton: a
-    altPositiveButton: d
+    altNegativeButton: 
+    altPositiveButton: 
     gravity: 3
     dead: 0.001
     sensitivity: 3
@@ -27,8 +27,8 @@ InputManager:
     descriptiveNegativeName: 
     negativeButton: down
     positiveButton: up
-    altNegativeButton: s
-    altPositiveButton: w
+    altNegativeButton: 
+    altPositiveButton: 
     gravity: 3
     dead: 0.001
     sensitivity: 3
@@ -485,3 +485,4 @@ InputManager:
     type: 2
     axis: 5
     joyNum: 0
+  m_UsePhysicalKeys: 0

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -12,6 +12,7 @@ TagManager:
   - Arrow
   - MagicProjectile
   - EnemySpawner
+  - Projectile Container
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Improvements:
- Ranger arrows are now slower
- Deleting arrows when restarting a frame

Bug Fixes:
- Now only able to move with the arrow keys
- Now only able to wall slide when we have the wall jump skill
- Added non friction material to platforms in the main scene
- Added non friction material to platform blocks prefabs
- Now only alive enemies will get alerted
- Now alerting enemies only within the designated area (some colliders had the enemy layer so it didn't work properly before)
- Now the `!` sign when enemies detect the player mantains the same size throughout the whole gameplay
- Now we are destroying the damage receiver, collider and damage dealer in arrows that hit the ground
- Now we are able to do jump attacks not only when jumping up, falling also works.
- Speed of magic now is constant, before it depended on the distance (now is normalized as a direction)
- Now when defeated in the boss scene, the camera restarts to its default camera
- 