### PR TITLE
Ground Monk Fixes

### DIFF
--- a/Assets/Scenes/Route 1.unity
+++ b/Assets/Scenes/Route 1.unity
@@ -35393,7 +35393,7 @@ MonoBehaviour:
   mainMenuUI: {fileID: 1609019670}
   pauseMenu: {fileID: 1231368549}
   countersUI: {fileID: 1009155021}
-  onMainMenu: 0
+  isOnMainMenu: 1
   isGamePaused: 0
 --- !u!1 &656666303
 GameObject:

--- a/Assets/Scripts/Characters/Enemies/Elementals/Ground Monk/GroundMonkAttacks.cs
+++ b/Assets/Scripts/Characters/Enemies/Elementals/Ground Monk/GroundMonkAttacks.cs
@@ -72,13 +72,13 @@ public class GroundMonkAttacks : EnemyAttacks
             switch (attackPattern)
             {
                 case 0:
-                    isAttackingCooldownCoroutine = StartCoroutine(IsAttackingCooldown(.6f));
+                    isAttackingCooldownCoroutine = StartCoroutine(IsAttackingCooldown(.75f));
                     break;
                 case 1:
-                    isAttackingCooldownCoroutine = StartCoroutine(IsAttackingCooldown(.9f));
+                    isAttackingCooldownCoroutine = StartCoroutine(IsAttackingCooldown(1.2f));
                     break;
                 case 2:
-                    isAttackingCooldownCoroutine = StartCoroutine(IsAttackingCooldown(1.4f));
+                    isAttackingCooldownCoroutine = StartCoroutine(IsAttackingCooldown(2f));
                     break;
             }
         }


### PR DESCRIPTION
- Fixes the times for the transformed ground monk attack, since those are played at a 80% speed, there was some delay to add to all the _IsAttackingCooldown_ methods called when transformed