### PR TITLE
Bug fixes

### DIFF
--- a/Assets/Prefabs/Characters/NPC's/Foxy - Intro.prefab
+++ b/Assets/Prefabs/Characters/NPC's/Foxy - Intro.prefab
@@ -308,7 +308,7 @@ MonoBehaviour:
   groundCheck: {fileID: 2102027488143269767}
   hasToJumpCheck: {fileID: 2102027488673808806}
   followCheck: {fileID: 2102027489911934791}
-  runSpeed: 2.5
+  runSpeed: 3
   movingTime: 1
 --- !u!1 &2102027488673808804
 GameObject:

--- a/Assets/Prefabs/Parallax Backgrounds/Caves.prefab
+++ b/Assets/Prefabs/Parallax Backgrounds/Caves.prefab
@@ -620,7 +620,7 @@ GameObject:
   - component: {fileID: 6497529401144640537}
   m_Layer: 0
   m_Name: 1 - Back
-  m_TagString: Untagged
+  m_TagString: ParallaxBackground
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -724,7 +724,7 @@ GameObject:
   - component: {fileID: 6497529401193739441}
   m_Layer: 0
   m_Name: 2 - Far
-  m_TagString: Untagged
+  m_TagString: ParallaxBackground
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1080,7 +1080,7 @@ GameObject:
   - component: {fileID: 6497529401818198156}
   m_Layer: 0
   m_Name: 3 - Middle
-  m_TagString: Untagged
+  m_TagString: ParallaxBackground
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/Parallax Backgrounds/Forest of Illusions.prefab
+++ b/Assets/Prefabs/Parallax Backgrounds/Forest of Illusions.prefab
@@ -222,7 +222,7 @@ GameObject:
   - component: {fileID: 1479590830}
   m_Layer: 0
   m_Name: Blurr Container
-  m_TagString: Untagged
+  m_TagString: ParallaxBackground
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -972,7 +972,7 @@ GameObject:
   - component: {fileID: 5848091101196896420}
   m_Layer: 0
   m_Name: Middle
-  m_TagString: Untagged
+  m_TagString: ParallaxBackground
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1514,7 +1514,7 @@ GameObject:
   - component: {fileID: 5848091102143672910}
   m_Layer: 0
   m_Name: Back
-  m_TagString: Untagged
+  m_TagString: ParallaxBackground
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/Parallax Backgrounds/Magic Cliffs.prefab
+++ b/Assets/Prefabs/Parallax Backgrounds/Magic Cliffs.prefab
@@ -924,7 +924,7 @@ GameObject:
   - component: {fileID: 875180813602268288}
   m_Layer: 0
   m_Name: 1 - Sky
-  m_TagString: Untagged
+  m_TagString: ParallaxBackground
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1200,7 +1200,7 @@ GameObject:
   - component: {fileID: 875180813922526602}
   m_Layer: 0
   m_Name: 4 - Far Grounds
-  m_TagString: Untagged
+  m_TagString: ParallaxBackground
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1304,7 +1304,7 @@ GameObject:
   - component: {fileID: 875180813934147447}
   m_Layer: 0
   m_Name: 2 - Clouds
-  m_TagString: Untagged
+  m_TagString: ParallaxBackground
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1912,7 +1912,7 @@ GameObject:
   - component: {fileID: 875180814948116409}
   m_Layer: 0
   m_Name: 3 - Sea
-  m_TagString: Untagged
+  m_TagString: ParallaxBackground
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/Parallax Backgrounds/Oak Woods.prefab
+++ b/Assets/Prefabs/Parallax Backgrounds/Oak Woods.prefab
@@ -316,7 +316,7 @@ GameObject:
   - component: {fileID: 5875849166917417528}
   m_Layer: 0
   m_Name: 1 - Back
-  m_TagString: Untagged
+  m_TagString: ParallaxBackground
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -420,7 +420,7 @@ GameObject:
   - component: {fileID: 5875849166985757006}
   m_Layer: 0
   m_Name: 3 - Front
-  m_TagString: Untagged
+  m_TagString: ParallaxBackground
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -608,7 +608,7 @@ GameObject:
   - component: {fileID: 5875849167117404990}
   m_Layer: 0
   m_Name: 2 - Middle
-  m_TagString: Untagged
+  m_TagString: ParallaxBackground
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/Parallax Backgrounds/Tall Forest.prefab
+++ b/Assets/Prefabs/Parallax Backgrounds/Tall Forest.prefab
@@ -452,7 +452,7 @@ GameObject:
   - component: {fileID: 3418582960259691036}
   m_Layer: 0
   m_Name: 2 - Middle
-  m_TagString: Untagged
+  m_TagString: ParallaxBackground
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -810,7 +810,7 @@ GameObject:
   - component: {fileID: 3418582961141161476}
   m_Layer: 0
   m_Name: 3 - Front
-  m_TagString: Untagged
+  m_TagString: ParallaxBackground
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1623,7 +1623,7 @@ GameObject:
   - component: {fileID: 3418582962120390302}
   m_Layer: 0
   m_Name: 1 - Back
-  m_TagString: Untagged
+  m_TagString: ParallaxBackground
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -37749,6 +37749,108 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 9017593654189137783, guid: eb80094e4095bbb4aa4ff7790fe0d3e9, type: 3}
   m_PrefabInstance: {fileID: 1531484747}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1240475568
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1240475569}
+  - component: {fileID: 1240475571}
+  - component: {fileID: 1240475572}
+  m_Layer: 14
+  m_Name: First Portal Block
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1240475569
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1240475568}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 15.96, y: -1.75, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2022899067}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &1240475571
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1240475568}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.3, y: 3}
+  m_EdgeRadius: 0
+--- !u!114 &1240475572
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1240475568}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9d3dbe3a42223b24a8cc44e36ba653fe, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  onPreSave:
+    m_PersistentCalls:
+      m_Calls: []
+    targetZUIDs: []
+  onPreLoad:
+    m_PersistentCalls:
+      m_Calls: []
+    targetZUIDs: []
+  onPostSave:
+    m_PersistentCalls:
+      m_Calls: []
+    targetZUIDs: []
+  onPostLoad:
+    m_PersistentCalls:
+      m_Calls: []
+    targetZUIDs: []
+  showSettings: 0
+  groupID: 0
+  _zuid: e3c2b5388b81e9e41b42749e656076fc
+  _gozuid: 57b8493cc0037a245a00d16b09f4a014
+  serializedComponents:
+  - typeFullName: UnityEngine.Transform, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+    persistenceType: 0
+    component: {fileID: 1240475569}
+    zuid: bf1059b12279363428170e0175e06ca8
+  - typeFullName: UnityEngine.BoxCollider2D, UnityEngine.Physics2DModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+    persistenceType: 0
+    component: {fileID: 1240475571}
+    zuid: 2443e39aaa48b4740ac97d8f8b02727c
 --- !u!1001 &1277919363
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -38297,6 +38399,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   cutscenesObject: {fileID: 1771974622}
+  portalBlock: {fileID: 1240475571}
 --- !u!114 &1462819830
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -41564,6 +41667,7 @@ Transform:
   m_Children:
   - {fileID: 1771974623}
   - {fileID: 1462819826}
+  - {fileID: 1240475569}
   m_Father: {fileID: 857667516}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scenes/Route 1.unity
+++ b/Assets/Scenes/Route 1.unity
@@ -6727,7 +6727,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 81318075}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -3.64, y: -0.45, z: 0}
+  m_LocalPosition: {x: -3.64, y: -0.26, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -50957,7 +50957,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1121704464}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.39000034, y: 30.25, z: -5}
+  m_LocalPosition: {x: 0.38999987, y: 30.44, z: -5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -51034,7 +51034,7 @@ Camera:
   far clip plane: 1000
   field of view: 60
   orthographic: 1
-  orthographic size: 1.5
+  orthographic size: 1.8
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
@@ -82731,7 +82731,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1915884736}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -3.3300002, y: -28.640001, z: -5}
+  m_LocalPosition: {x: -3.3300002, y: -28.58, z: -5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -82778,7 +82778,7 @@ MonoBehaviour:
   m_Follow: {fileID: 505556033}
   m_Lens:
     FieldOfView: 60
-    OrthographicSize: 1.5
+    OrthographicSize: 1.8
     NearClipPlane: 0.3
     FarClipPlane: 1000
     Dutch: 0

--- a/Assets/Scripts/Animations/ParallaxBackground.cs
+++ b/Assets/Scripts/Animations/ParallaxBackground.cs
@@ -1,4 +1,6 @@
 using UnityEngine;
+using System.Collections;
+using Cinemachine;
 
 #if UNITY_EDITOR
 using UnityEditor;
@@ -13,7 +15,8 @@ public class ParallaxBackground : MonoBehaviour
 
     [SerializeField] private bool repeatingXAxis = true;
 
-    private float startPositionY, currentPositionX, currentPositionY, width, limitY;
+    private float startPositionY, currentPositionX, currentPositionY, width;
+    private float limitY = -1;
 
     private Vector3 lastCameraPosition;
 
@@ -35,11 +38,24 @@ public class ParallaxBackground : MonoBehaviour
         currentPositionY = startPositionY;
 
         width = GetComponent<SpriteRenderer>().bounds.size.x;
-        limitY = ((GetComponent<SpriteRenderer>().size.y * GetComponent<SpriteRenderer>().transform.localScale.y) - (Camera.main.orthographicSize * 2f)) / 2f;
+
+        StartCoroutine(SetYLimit());
+    }
+
+    public IEnumerator SetYLimit()
+    {
+        yield return new WaitForSeconds(Config.MEDIUM_DELAY);
+
+        CinemachineVirtualCamera vcam = GameObject.FindGameObjectWithTag(Config.CINEMACHINE_CAMERA_TAG).GetComponent<CinemachineVirtualCamera>();
+
+        limitY = ((GetComponent<SpriteRenderer>().size.y * GetComponent<SpriteRenderer>().transform.localScale.y) - (vcam.m_Lens.OrthographicSize * 2f)) / 2f;
     }
 
     private void LateUpdate()
     {
+        if (!bottomOnlySprite && limitY == -1)
+            return;
+
         float deltaXFromCamera = (cameraTransform.position.x * (1 - parallaxEffect.x));
         float deltaXPosition = cameraTransform.position.x * parallaxEffect.x;
 

--- a/Assets/Scripts/Config.cs
+++ b/Assets/Scripts/Config.cs
@@ -14,6 +14,7 @@ public class Config
     public const string GROUND_TAG = "Ground";
     public const string SPAWN_POINT_TAG = "Spawn Point";
     public const string CINEMACHINE_CAMERA_TAG = "CinemachineCamera";
+    public const string PARALLAX_BACKGROUND_TAG = "ParallaxBackground";
 
     #endregion
 

--- a/Assets/Scripts/Cutscenes/01 Intro/FoxyGoal.cs
+++ b/Assets/Scripts/Cutscenes/01 Intro/FoxyGoal.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 public class FoxyGoal : MonoBehaviour
 {
     [SerializeField] private GameObject cutscenesObject;
+    [SerializeField] BoxCollider2D portalBlock;
 
     private BoxCollider arrivedCheck;
     private bool hasArrived = false;
@@ -22,6 +23,9 @@ public class FoxyGoal : MonoBehaviour
 
             GameObject.FindGameObjectWithTag("Foxy").GetComponent<FoxyController>().FlipTowardsPlayer();
             cutscenesObject.GetComponent<Cutscene02>().enabled = true;
+
+            portalBlock.enabled = false;
+            portalBlock.gameObject.SetActive(false);
 
             this.gameObject.SetActive(false);
         }

--- a/Assets/Scripts/Dialogue System/DialogueManager.cs
+++ b/Assets/Scripts/Dialogue System/DialogueManager.cs
@@ -143,6 +143,8 @@ public class DialogueManager : MonoBehaviour
 
     public void ClearDialogues()
     {
+        StopAllCoroutines();
+
         dialogueBubbles.Clear();
 
         foreach (Transform child in transform)

--- a/Assets/Scripts/Dialogue System/DialogueManager.cs
+++ b/Assets/Scripts/Dialogue System/DialogueManager.cs
@@ -140,4 +140,16 @@ public class DialogueManager : MonoBehaviour
             }
         }
     }
+
+    public void ClearDialogues()
+    {
+        dialogueBubbles.Clear();
+
+        foreach (Transform child in transform)
+        {
+            StartCoroutine(child.gameObject.GetComponent<DialogueBubble>().CloseDialogueBubble());
+        }
+
+        isRunning = false;
+    }
 }

--- a/Assets/Scripts/Frames/FrameManager.cs
+++ b/Assets/Scripts/Frames/FrameManager.cs
@@ -71,6 +71,12 @@ public class FrameManager : MonoBehaviour
         activeFrame.gameObject.SetActive(true);
         activeFrame.StartFrame();
 
+        GameObject[] parallaxBackgrounds = GameObject.FindGameObjectsWithTag(Config.PARALLAX_BACKGROUND_TAG);
+        foreach (GameObject parallaxBackground in parallaxBackgrounds)
+        {
+            parallaxBackground.GetComponent<ParallaxBackground>().SetYLimit();
+        }
+
         yield return new WaitForSeconds(Config.END_TRANSITION_DURATION);
 
         GameManager.instance.GetPlayer().GetComponent<Rigidbody2D>().constraints = RigidbodyConstraints2D.FreezeRotation;

--- a/Assets/Scripts/Interactible/Colliders/BoxCollider.cs
+++ b/Assets/Scripts/Interactible/Colliders/BoxCollider.cs
@@ -6,6 +6,8 @@ public class BoxCollider : GeneralCollider
 {
     protected BoxCollider2D boxCollider;
 
+    protected float timeToCheck = 0;
+
     protected virtual void Awake()
     {
         boxCollider = GetComponent<BoxCollider2D>();
@@ -13,8 +15,12 @@ public class BoxCollider : GeneralCollider
 
     protected virtual void Update()
     {
-        if (!isColliding)
+        timeToCheck -= Time.deltaTime;
+
+        if (!isColliding || timeToCheck < 0)
         {
+            timeToCheck = 1f;
+
             boxCollider.OverlapCollider(filter, hits);
 
             for (int i = 0; i < hits.Length; i++)

--- a/Assets/Scripts/Interactible/Colliders/CircleCollider.cs
+++ b/Assets/Scripts/Interactible/Colliders/CircleCollider.cs
@@ -6,6 +6,8 @@ public class CircleCollider : GeneralCollider
 {
     private CircleCollider2D circleCollider;
 
+    protected float timeToCheck = 0;
+
     protected virtual void Awake()
     {
         circleCollider = GetComponent<CircleCollider2D>();
@@ -13,8 +15,12 @@ public class CircleCollider : GeneralCollider
 
     protected virtual void Update()
     {
-        if (!isColliding)
+        timeToCheck -= Time.deltaTime;
+
+        if (!isColliding || timeToCheck < 0)
         {
+            timeToCheck = 1f;
+
             circleCollider.OverlapCollider(filter, hits);
 
             for (int i = 0; i < hits.Length; i++)

--- a/Assets/Scripts/Interactible/Portal.cs
+++ b/Assets/Scripts/Interactible/Portal.cs
@@ -35,6 +35,8 @@ public class Portal : GeneralCollider
     {
         GameManager.instance.SetIsTeleporting(true);
 
+        GameManager.instance.GetDialogueManager().ClearDialogues();
+
         CurrentProgressManager currentProgressManager = GameManager.instance.GetCurrentProgressManager();
 
         if (currentProgressManager.FirstTimePlaying)

--- a/Assets/Scripts/Managers/AnimationManager.cs
+++ b/Assets/Scripts/Managers/AnimationManager.cs
@@ -148,4 +148,17 @@ public class AnimationManager : MonoBehaviour
             Destroy(child.gameObject);
         }
     }
+
+    public void ClearScreenOverlayCanvas()
+    {
+        ShowImageUI(Config.SPACE_KEY_GUI, false);
+        ShowImageUI(Config.RIGHT_ARROW_GUI, false);
+        ShowImageUI(Config.LEFT_ARROW_GUI, false);
+    }
+
+    public void ClearCanvases()
+    {
+        ClearWorldSpaceCanvas();
+        ClearScreenOverlayCanvas();
+    }
 }

--- a/Assets/Scripts/Managers/CurrentProgressManager.cs
+++ b/Assets/Scripts/Managers/CurrentProgressManager.cs
@@ -209,18 +209,9 @@ public class CurrentProgressManager : MonoBehaviour
 
         ProgressManager.Save();
 
-        Counters updatedCounters = new Counters()
-        {
-            EnemiesKilledCount = enemiesKilledCount,
-            DeathsCount = deathsCount,
-            TimePlayed = timePlayed
-        };
-
-        Settings.Instance.savedGamesCounters[ZSerializer.ZSerializerSettings.Instance.selectedSaveFile] = updatedCounters;
-        Settings.Instance.savedGamesCountersSerialized = Settings.Instance.savedGamesCounters;
+        Settings.Instance.SaveCounters(enemiesKilledCount, deathsCount, timePlayed);
 
         Settings.Save();
-
     }
 
     #region Show Counters

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -65,6 +65,7 @@ public class GameManager : MonoBehaviour
             instance = this;
 
             ProgressManager.Instance.Reset();
+
             Settings.Load();
             Settings.Instance.Deserialize();
         }
@@ -88,9 +89,7 @@ public class GameManager : MonoBehaviour
 
     public void OnSceneLoaded(Scene scene, LoadSceneMode mode)
     {
-        GameManager.instance.GetAnimationManager().ShowImageUI(Config.SPACE_KEY_GUI, false);
-        GameManager.instance.GetAnimationManager().ShowImageUI(Config.RIGHT_ARROW_GUI, false);
-        GameManager.instance.GetAnimationManager().ShowImageUI(Config.LEFT_ARROW_GUI, false);
+        animationManager.ClearCanvases();
 
         if (!isOnMainMenu)
         {

--- a/Assets/Scripts/UI/MainMenuUI.cs
+++ b/Assets/Scripts/UI/MainMenuUI.cs
@@ -82,10 +82,10 @@ public class MainMenuUI : MonoBehaviour
 
             int savedGameIndex = Settings.Instance.currentSavedGames[i];
 
-            killsTexts[i].text = Settings.Instance.savedGamesCounters[savedGameIndex].EnemiesKilledCount.ToString("#,##0");
-            deathsTexts[i].text = Settings.Instance.savedGamesCounters[savedGameIndex].DeathsCount.ToString("#,##0");
+            killsTexts[i].text = Settings.Instance.savedGamesKillsCounter[savedGameIndex].ToString("#,##0");
+            deathsTexts[i].text = Settings.Instance.savedGamesDeathsCounter[savedGameIndex].ToString("#,##0");
 
-            float timePlayedFloat = Settings.Instance.savedGamesCounters[savedGameIndex].TimePlayed;
+            float timePlayedFloat = Settings.Instance.savedGamesTimePlayedCounter[savedGameIndex];
             string time = GameManager.instance.FloatToTimeFormat(timePlayedFloat);
             timePlayedTexts[i].text = time;
         }
@@ -97,10 +97,10 @@ public class MainMenuUI : MonoBehaviour
 
         int correctedSavedGameIndex = Settings.Instance.currentSavedGames[savedGameIndex];
 
-        savedGameKillsTexts[savedGameIndex].text = Settings.Instance.savedGamesCounters[correctedSavedGameIndex].EnemiesKilledCount.ToString("#,##0");
-        savedGameDeathsTexts[savedGameIndex].text = Settings.Instance.savedGamesCounters[correctedSavedGameIndex].DeathsCount.ToString("#,##0");
+        savedGameKillsTexts[savedGameIndex].text = Settings.Instance.savedGamesKillsCounter[correctedSavedGameIndex].ToString("#,##0");
+        savedGameDeathsTexts[savedGameIndex].text = Settings.Instance.savedGamesDeathsCounter[correctedSavedGameIndex].ToString("#,##0");
 
-        float timePlayedFloat = Settings.Instance.savedGamesCounters[correctedSavedGameIndex].TimePlayed;
+        float timePlayedFloat = Settings.Instance.savedGamesTimePlayedCounter[correctedSavedGameIndex];
         string time = GameManager.instance.FloatToTimeFormat(timePlayedFloat);
         savedGameTimePlayedTexts[savedGameIndex].text = time;
     }

--- a/Assets/ZResources/ZSerializer/GlobalObjects/Resources/Settings.asset
+++ b/Assets/ZResources/ZSerializer/GlobalObjects/Resources/Settings.asset
@@ -12,19 +12,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 17526797d331c334d804f96cc09d54c4, type: 3}
   m_Name: Settings
   m_EditorClassIdentifier: 
-  newGameIndex: 2
-  savedGamesAmount: 2
-  currentSavedGames: 0000000001000000
+  newGameIndex: 0
+  savedGamesAmount: 0
+  currentSavedGames: 
   savedGamesKillsCounterSerialized:
-    keys: 0000000001000000
-    values: 0d00000001000000
+    keys: 
+    values: 
   savedGamesDeathsCounterSerialized:
-    keys: 0000000001000000
-    values: 0400000003000000
+    keys: 
+    values: 
   savedGamesTimePlayedCounterSerialized:
-    keys: 0000000001000000
-    values:
-    - 85.74089
-    - 40.83316
+    keys: 
+    values: []
   musicVolume: 1
   SFXVolume: 1

--- a/Assets/ZResources/ZSerializer/GlobalObjects/Resources/Settings.asset
+++ b/Assets/ZResources/ZSerializer/GlobalObjects/Resources/Settings.asset
@@ -12,11 +12,19 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 17526797d331c334d804f96cc09d54c4, type: 3}
   m_Name: Settings
   m_EditorClassIdentifier: 
-  newGameIndex: 1
-  savedGamesAmount: 1
-  currentSavedGames: 00000000
-  savedGamesCountersSerialized:
-    keys: 00000000
-    values: []
+  newGameIndex: 2
+  savedGamesAmount: 2
+  currentSavedGames: 0000000001000000
+  savedGamesKillsCounterSerialized:
+    keys: 0000000001000000
+    values: 0d00000001000000
+  savedGamesDeathsCounterSerialized:
+    keys: 0000000001000000
+    values: 0400000003000000
+  savedGamesTimePlayedCounterSerialized:
+    keys: 0000000001000000
+    values:
+    - 85.74089
+    - 40.83316
   musicVolume: 1
   SFXVolume: 1

--- a/Assets/ZResources/ZSerializer/GlobalObjects/Source/Settings.cs
+++ b/Assets/ZResources/ZSerializer/GlobalObjects/Source/Settings.cs
@@ -9,17 +9,37 @@ public partial class Settings
     public int savedGamesAmount = 0;
     public List<int> currentSavedGames = new List<int>();
 
-    public ZDictionary<int, Counters> savedGamesCountersSerialized = new ZDictionary<int, Counters>();
-    public Dictionary<int, Counters> savedGamesCounters = new Dictionary<int, Counters>();
+    public ZDictionary<int, int> savedGamesKillsCounterSerialized = new ZDictionary<int, int>();
+    public Dictionary<int, int> savedGamesKillsCounter = new Dictionary<int, int>();
+
+    public ZDictionary<int, int> savedGamesDeathsCounterSerialized = new ZDictionary<int, int>();
+    public Dictionary<int, int> savedGamesDeathsCounter = new Dictionary<int, int>();
+
+    public ZDictionary<int, float> savedGamesTimePlayedCounterSerialized = new ZDictionary<int, float>();
+    public Dictionary<int, float> savedGamesTimePlayedCounter = new Dictionary<int, float>();
 
     public float musicVolume = 1;
     public float SFXVolume = 1;
 
+    public void SaveCounters(int enemiesKilledCount, int deathsCount, float timePlayed)
+    {
+        savedGamesKillsCounter[ZSerializerSettings.Instance.selectedSaveFile] = enemiesKilledCount;
+        savedGamesKillsCounterSerialized = savedGamesKillsCounter;
+
+        savedGamesDeathsCounter[ZSerializerSettings.Instance.selectedSaveFile] = deathsCount;
+        savedGamesDeathsCounterSerialized = savedGamesDeathsCounter;
+
+        savedGamesTimePlayedCounter[ZSerializerSettings.Instance.selectedSaveFile] = timePlayed;
+        savedGamesTimePlayedCounterSerialized = savedGamesTimePlayedCounter;
+    }
+
     public void Deserialize()
     {
-        for (var i = 0; i < savedGamesCountersSerialized.keys.Count; i++)
+        for (var i = 0; i < currentSavedGames.Count; i++)
         {
-            savedGamesCounters.Add(savedGamesCountersSerialized.keys[i], savedGamesCountersSerialized.values[i]);
+            savedGamesKillsCounter.Add(savedGamesKillsCounterSerialized.keys[i], savedGamesKillsCounterSerialized.values[i]);
+            savedGamesDeathsCounter.Add(savedGamesDeathsCounterSerialized.keys[i], savedGamesDeathsCounterSerialized.values[i]);
+            savedGamesTimePlayedCounter.Add(savedGamesTimePlayedCounterSerialized.keys[i], savedGamesTimePlayedCounterSerialized.values[i]);
         }
     }
 
@@ -39,8 +59,7 @@ public partial class Settings
         {
             currentSavedGames.Add(newGameIndex);
 
-            savedGamesCounters.Add(newGameIndex, new Counters());
-            savedGamesCountersSerialized = savedGamesCounters;
+            AddNewCounters(newGameIndex);
 
             ZSerializerSettings.Instance.selectedSaveFile = newGameIndex;
             ProgressManager.Save();
@@ -65,11 +84,34 @@ public partial class Settings
 
         currentSavedGames.Remove(correctedIndex);
 
-        savedGamesCounters.Remove(correctedIndex);
-        savedGamesCountersSerialized = savedGamesCounters;
+        RemoveCounters(correctedIndex);
 
         savedGamesAmount--;
 
         Save();
+    }
+
+    private void AddNewCounters(int newGameIndex)
+    {
+        savedGamesKillsCounter.Add(newGameIndex, 0);
+        savedGamesKillsCounterSerialized = savedGamesKillsCounter;
+
+        savedGamesDeathsCounter.Add(newGameIndex, 0);
+        savedGamesDeathsCounterSerialized = savedGamesDeathsCounter;
+
+        savedGamesTimePlayedCounter.Add(newGameIndex, 0);
+        savedGamesTimePlayedCounterSerialized = savedGamesTimePlayedCounter;
+    }
+
+    private void RemoveCounters(int correctedGameIndex)
+    {
+        savedGamesKillsCounter.Remove(correctedGameIndex);
+        savedGamesKillsCounterSerialized = savedGamesKillsCounter;
+
+        savedGamesDeathsCounter.Remove(correctedGameIndex);
+        savedGamesDeathsCounterSerialized = savedGamesDeathsCounter;
+
+        savedGamesTimePlayedCounter.Remove(correctedGameIndex);
+        savedGamesTimePlayedCounterSerialized = savedGamesTimePlayedCounter;
     }
 }

--- a/ProjectSettings/Physics2DSettings.asset
+++ b/ProjectSettings/Physics2DSettings.asset
@@ -53,4 +53,4 @@ Physics2DSettings:
   m_ColliderAsleepColor: {r: 0.5686275, g: 0.95686275, b: 0.54509807, a: 0.36078432}
   m_ColliderContactColor: {r: 1, g: 0, b: 1, a: 0.6862745}
   m_ColliderAABBColor: {r: 1, g: 1, b: 0, a: 0.2509804}
-  m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc2ffffffc7ffffffe2ffffffe0ffffffe0fffffffcffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  m_LayerCollisionMatrix: ffbfffffffbfffffffbfffffffffffffffbfffffffbfffffffffffffffffffffff82ffffffc7ffffffa2ffffffe0ffffffa0ffffffbcffffc8caffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -33,7 +33,7 @@ TagManager:
   - Dash
   - Dead
   - NPC
-  - 
+  - PlayerBlock
   - 
   - 
   - 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -18,6 +18,7 @@ TagManager:
   - Foxy
   - Cutscene
   - Breakable
+  - ParallaxBackground
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
- Now closing all dialgoue bubbles before changing scenes
- Now deactivating all animations (worldspace and overlay) when loading a new scene
- Counters weren't serialized before, so we changed them to three dictionaries instead: kills, deaths and time played
- Added a collider to stop player from going to the portal before the second cutscene is played
- Parallax effect had a problem were it would set its y limits depending on the main camera, but cinemachine virtual cameras could change the size of the camera, resulting in problems. Now checking the vcam size instead (also refreshing it every new frame is loaded (not fps frames, but fighting frames))
- when dashing, as we changed the player layer, some colliders were still colliding with the player since it wouldn't activate the `OnTriggerExit` method, now added a check every second to all colliders to be certain that won't happen