### PR TITLE
Main Scene Decorations

### DIFF
--- a/Assets/Animations/Interactible/Breakable Directional Sign.meta
+++ b/Assets/Animations/Interactible/Breakable Directional Sign.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: aa9da0b36a1275e4b83e2d4f2bc9286e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animations/Interactible/Breakable Directional Sign/Death.anim
+++ b/Assets/Animations/Interactible/Breakable Directional Sign/Death.anim
@@ -20,19 +20,17 @@ AnimationClip:
   m_PPtrCurves:
   - curve:
     - time: 0
-      value: {fileID: 881957049, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
+      value: {fileID: 263418143, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
     - time: 0.1
-      value: {fileID: -330289099, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
+      value: {fileID: -1021008946, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
     - time: 0.2
-      value: {fileID: -672781309, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
+      value: {fileID: -1104087121, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
     - time: 0.3
-      value: {fileID: -257826623, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
+      value: {fileID: 249226462, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
     - time: 0.4
-      value: {fileID: -430588310, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
+      value: {fileID: 1490453619, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
     - time: 0.5
-      value: {fileID: -761304557, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
-    - time: 0.6
-      value: {fileID: 2012514748, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
+      value: {fileID: -1895191847, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
     attribute: m_Sprite
     path: 
     classID: 212
@@ -52,19 +50,18 @@ AnimationClip:
       customType: 23
       isPPtrCurve: 1
     pptrCurveMapping:
-    - {fileID: 881957049, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
-    - {fileID: -330289099, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
-    - {fileID: -672781309, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
-    - {fileID: -257826623, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
-    - {fileID: -430588310, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
-    - {fileID: -761304557, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
-    - {fileID: 2012514748, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
+    - {fileID: 263418143, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
+    - {fileID: -1021008946, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
+    - {fileID: -1104087121, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
+    - {fileID: 249226462, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
+    - {fileID: 1490453619, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
+    - {fileID: -1895191847, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 0.70000005
+    m_StopTime: 0.6
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0

--- a/Assets/Animations/Interactible/Breakable Directional Sign/Death.anim.meta
+++ b/Assets/Animations/Interactible/Breakable Directional Sign/Death.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 226a3828fb43164448c31e2502cea3d7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animations/Interactible/Breakable Directional Sign/Directional Sign.controller
+++ b/Assets/Animations/Interactible/Breakable Directional Sign/Directional Sign.controller
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1107 &-8466737749904372180
+--- !u!1107 &-6367022635158089185
 AnimatorStateMachine:
   serializedVersion: 6
   m_ObjectHideFlags: 1
@@ -10,11 +10,11 @@ AnimatorStateMachine:
   m_Name: Base Layer
   m_ChildStates:
   - serializedVersion: 1
-    m_State: {fileID: 3146385575677378727}
+    m_State: {fileID: 3030008487690041244}
     m_Position: {x: 270, y: 110, z: 0}
   - serializedVersion: 1
-    m_State: {fileID: 6297029714422189166}
-    m_Position: {x: 270, y: 270, z: 0}
+    m_State: {fileID: 6248455192766355693}
+    m_Position: {x: 270, y: 200, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []
@@ -24,8 +24,8 @@ AnimatorStateMachine:
   m_EntryPosition: {x: 50, y: 120, z: 0}
   m_ExitPosition: {x: 800, y: 120, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
-  m_DefaultState: {fileID: 3146385575677378727}
---- !u!1101 &-828049607174618037
+  m_DefaultState: {fileID: 3030008487690041244}
+--- !u!1101 &-1269936266441734230
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
@@ -37,14 +37,14 @@ AnimatorStateTransition:
     m_ConditionEvent: Death
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: 6297029714422189166}
+  m_DstState: {fileID: 6248455192766355693}
   m_Solo: 0
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
   m_TransitionDuration: 0
   m_TransitionOffset: 0
-  m_ExitTime: 0.88095236
+  m_ExitTime: 0
   m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
@@ -56,7 +56,7 @@ AnimatorController:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: Breakable Barrel
+  m_Name: Directional Sign
   serializedVersion: 5
   m_AnimatorParameters:
   - m_Name: Death
@@ -74,7 +74,7 @@ AnimatorController:
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
-    m_StateMachine: {fileID: -8466737749904372180}
+    m_StateMachine: {fileID: -6367022635158089185}
     m_Mask: {fileID: 0}
     m_Motions: []
     m_Behaviours: []
@@ -84,7 +84,7 @@ AnimatorController:
     m_IKPass: 0
     m_SyncedLayerAffectsTiming: 0
     m_Controller: {fileID: 9100000}
---- !u!1102 &3146385575677378727
+--- !u!1102 &3030008487690041244
 AnimatorState:
   serializedVersion: 6
   m_ObjectHideFlags: 1
@@ -95,7 +95,7 @@ AnimatorState:
   m_Speed: 1
   m_CycleOffset: 0
   m_Transitions:
-  - {fileID: -828049607174618037}
+  - {fileID: -1269936266441734230}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -105,13 +105,13 @@ AnimatorState:
   m_MirrorParameterActive: 0
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
-  m_Motion: {fileID: 7400000, guid: 6ad82f5832fd673419cacac9bc282afb, type: 2}
+  m_Motion: {fileID: 7400000, guid: c3154534cf14d904e8e82261824affa0, type: 2}
   m_Tag: 
   m_SpeedParameter: 
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
---- !u!1102 &6297029714422189166
+--- !u!1102 &6248455192766355693
 AnimatorState:
   serializedVersion: 6
   m_ObjectHideFlags: 1
@@ -131,7 +131,7 @@ AnimatorState:
   m_MirrorParameterActive: 0
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
-  m_Motion: {fileID: 7400000, guid: 502c0adb173556f438d424db94c32b02, type: 2}
+  m_Motion: {fileID: 7400000, guid: 226a3828fb43164448c31e2502cea3d7, type: 2}
   m_Tag: 
   m_SpeedParameter: 
   m_MirrorParameter: 

--- a/Assets/Animations/Interactible/Breakable Directional Sign/Directional Sign.controller.meta
+++ b/Assets/Animations/Interactible/Breakable Directional Sign/Directional Sign.controller.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2d5ef556d8834b644b55e5ebd6c65562
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 9100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animations/Interactible/Breakable Directional Sign/Idle.anim
+++ b/Assets/Animations/Interactible/Breakable Directional Sign/Idle.anim
@@ -1,0 +1,68 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Idle
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - curve:
+    - time: 0
+      value: {fileID: 263418143, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+  m_SampleRate: 10
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+    pptrCurveMapping:
+    - {fileID: 263418143, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.1
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Animations/Interactible/Breakable Directional Sign/Idle.anim.meta
+++ b/Assets/Animations/Interactible/Breakable Directional Sign/Idle.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c3154534cf14d904e8e82261824affa0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animations/Interactible/Breakable Sign.meta
+++ b/Assets/Animations/Interactible/Breakable Sign.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 35b245d40c68e7946b12a9014d7bdf62
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animations/Interactible/Breakable Sign/Breakable Sign.controller
+++ b/Assets/Animations/Interactible/Breakable Sign/Breakable Sign.controller
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1107 &-8466737749904372180
+--- !u!1107 &-8366745009361134724
 AnimatorStateMachine:
   serializedVersion: 6
   m_ObjectHideFlags: 1
@@ -10,11 +10,11 @@ AnimatorStateMachine:
   m_Name: Base Layer
   m_ChildStates:
   - serializedVersion: 1
-    m_State: {fileID: 3146385575677378727}
-    m_Position: {x: 270, y: 110, z: 0}
+    m_State: {fileID: 4022883554805656002}
+    m_Position: {x: 280, y: 120, z: 0}
   - serializedVersion: 1
-    m_State: {fileID: 6297029714422189166}
-    m_Position: {x: 270, y: 270, z: 0}
+    m_State: {fileID: -6632228848021428639}
+    m_Position: {x: 280, y: 220, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []
@@ -24,94 +24,8 @@ AnimatorStateMachine:
   m_EntryPosition: {x: 50, y: 120, z: 0}
   m_ExitPosition: {x: 800, y: 120, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
-  m_DefaultState: {fileID: 3146385575677378727}
---- !u!1101 &-828049607174618037
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions:
-  - m_ConditionMode: 1
-    m_ConditionEvent: Death
-    m_EventTreshold: 0
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: 6297029714422189166}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0
-  m_TransitionOffset: 0
-  m_ExitTime: 0.88095236
-  m_HasExitTime: 0
-  m_HasFixedDuration: 1
-  m_InterruptionSource: 0
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
---- !u!91 &9100000
-AnimatorController:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: Breakable Barrel
-  serializedVersion: 5
-  m_AnimatorParameters:
-  - m_Name: Death
-    m_Type: 9
-    m_DefaultFloat: 0
-    m_DefaultInt: 0
-    m_DefaultBool: 0
-    m_Controller: {fileID: 0}
-  - m_Name: IsDead
-    m_Type: 4
-    m_DefaultFloat: 0
-    m_DefaultInt: 0
-    m_DefaultBool: 0
-    m_Controller: {fileID: 0}
-  m_AnimatorLayers:
-  - serializedVersion: 5
-    m_Name: Base Layer
-    m_StateMachine: {fileID: -8466737749904372180}
-    m_Mask: {fileID: 0}
-    m_Motions: []
-    m_Behaviours: []
-    m_BlendingMode: 0
-    m_SyncedLayerIndex: -1
-    m_DefaultWeight: 0
-    m_IKPass: 0
-    m_SyncedLayerAffectsTiming: 0
-    m_Controller: {fileID: 9100000}
---- !u!1102 &3146385575677378727
-AnimatorState:
-  serializedVersion: 6
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: Idle
-  m_Speed: 1
-  m_CycleOffset: 0
-  m_Transitions:
-  - {fileID: -828049607174618037}
-  m_StateMachineBehaviours: []
-  m_Position: {x: 50, y: 50, z: 0}
-  m_IKOnFeet: 0
-  m_WriteDefaultValues: 1
-  m_Mirror: 0
-  m_SpeedParameterActive: 0
-  m_MirrorParameterActive: 0
-  m_CycleOffsetParameterActive: 0
-  m_TimeParameterActive: 0
-  m_Motion: {fileID: 7400000, guid: 6ad82f5832fd673419cacac9bc282afb, type: 2}
-  m_Tag: 
-  m_SpeedParameter: 
-  m_MirrorParameter: 
-  m_CycleOffsetParameter: 
-  m_TimeParameter: 
---- !u!1102 &6297029714422189166
+  m_DefaultState: {fileID: 4022883554805656002}
+--- !u!1102 &-6632228848021428639
 AnimatorState:
   serializedVersion: 6
   m_ObjectHideFlags: 1
@@ -131,7 +45,93 @@ AnimatorState:
   m_MirrorParameterActive: 0
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
-  m_Motion: {fileID: 7400000, guid: 502c0adb173556f438d424db94c32b02, type: 2}
+  m_Motion: {fileID: 7400000, guid: 3e409694b9674c6499f625a71053937f, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &-1280090832182436465
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Death
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -6632228848021428639}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!91 &9100000
+AnimatorController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Breakable Sign
+  serializedVersion: 5
+  m_AnimatorParameters:
+  - m_Name: Death
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
+  - m_Name: IsDead
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
+  m_AnimatorLayers:
+  - serializedVersion: 5
+    m_Name: Base Layer
+    m_StateMachine: {fileID: -8366745009361134724}
+    m_Mask: {fileID: 0}
+    m_Motions: []
+    m_Behaviours: []
+    m_BlendingMode: 0
+    m_SyncedLayerIndex: -1
+    m_DefaultWeight: 0
+    m_IKPass: 0
+    m_SyncedLayerAffectsTiming: 0
+    m_Controller: {fileID: 9100000}
+--- !u!1102 &4022883554805656002
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Idle
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: -1280090832182436465}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 99cabde26d7da0440baf35b7fa89e200, type: 2}
   m_Tag: 
   m_SpeedParameter: 
   m_MirrorParameter: 

--- a/Assets/Animations/Interactible/Breakable Sign/Breakable Sign.controller.meta
+++ b/Assets/Animations/Interactible/Breakable Sign/Breakable Sign.controller.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2df85185006926a4c9e9047ea7d10820
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 9100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animations/Interactible/Breakable Sign/Death.anim
+++ b/Assets/Animations/Interactible/Breakable Sign/Death.anim
@@ -20,19 +20,17 @@ AnimationClip:
   m_PPtrCurves:
   - curve:
     - time: 0
-      value: {fileID: 881957049, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
+      value: {fileID: -251750564, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
     - time: 0.1
-      value: {fileID: -330289099, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
+      value: {fileID: -2127327079, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
     - time: 0.2
-      value: {fileID: -672781309, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
+      value: {fileID: 869352581, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
     - time: 0.3
-      value: {fileID: -257826623, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
+      value: {fileID: -1802549372, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
     - time: 0.4
-      value: {fileID: -430588310, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
+      value: {fileID: 557433799, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
     - time: 0.5
-      value: {fileID: -761304557, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
-    - time: 0.6
-      value: {fileID: 2012514748, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
+      value: {fileID: 1490086492, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
     attribute: m_Sprite
     path: 
     classID: 212
@@ -52,19 +50,18 @@ AnimationClip:
       customType: 23
       isPPtrCurve: 1
     pptrCurveMapping:
-    - {fileID: 881957049, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
-    - {fileID: -330289099, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
-    - {fileID: -672781309, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
-    - {fileID: -257826623, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
-    - {fileID: -430588310, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
-    - {fileID: -761304557, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
-    - {fileID: 2012514748, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
+    - {fileID: -251750564, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
+    - {fileID: -2127327079, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
+    - {fileID: 869352581, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
+    - {fileID: -1802549372, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
+    - {fileID: 557433799, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
+    - {fileID: 1490086492, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 0.70000005
+    m_StopTime: 0.6
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0

--- a/Assets/Animations/Interactible/Breakable Sign/Death.anim.meta
+++ b/Assets/Animations/Interactible/Breakable Sign/Death.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3e409694b9674c6499f625a71053937f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animations/Interactible/Breakable Sign/Idle.anim
+++ b/Assets/Animations/Interactible/Breakable Sign/Idle.anim
@@ -1,0 +1,68 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Idle
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - curve:
+    - time: 0
+      value: {fileID: -251750564, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+  m_SampleRate: 10
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+    pptrCurveMapping:
+    - {fileID: -251750564, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.1
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Animations/Interactible/Breakable Sign/Idle.anim.meta
+++ b/Assets/Animations/Interactible/Breakable Sign/Idle.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 99cabde26d7da0440baf35b7fa89e200
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Artwork/Interactible/Destructible Objects Sprite Sheet.png.meta
+++ b/Assets/Artwork/Interactible/Destructible Objects Sprite Sheet.png.meta
@@ -262,6 +262,258 @@ TextureImporter:
       indices: 
       edges: []
       weights: []
+    - serializedVersion: 2
+      name: Sign 0
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 254
+        width: 64
+        height: 64
+      alignment: 9
+      pivot: {x: 0.525, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: e360801cdd330de428ddff4454bf30e8
+      internalID: -251750564
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Sign 1
+      rect:
+        serializedVersion: 2
+        x: 64
+        y: 254
+        width: 64
+        height: 64
+      alignment: 9
+      pivot: {x: 0.525, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 4a58ce85e9bd3f042b2d53aa9a717421
+      internalID: -2127327079
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Sign 2
+      rect:
+        serializedVersion: 2
+        x: 128
+        y: 254
+        width: 64
+        height: 64
+      alignment: 9
+      pivot: {x: 0.525, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: c66a01a2facc94b4691ea1fb826893eb
+      internalID: 869352581
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Sign 3
+      rect:
+        serializedVersion: 2
+        x: 192
+        y: 254
+        width: 64
+        height: 64
+      alignment: 9
+      pivot: {x: 0.525, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 5d48cae4fbd971546a324eb4478e740b
+      internalID: -1802549372
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Sign 4
+      rect:
+        serializedVersion: 2
+        x: 256
+        y: 254
+        width: 64
+        height: 64
+      alignment: 9
+      pivot: {x: 0.525, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 251f4cf29cf6b92489bfb8944513ba0b
+      internalID: 557433799
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Sign 5
+      rect:
+        serializedVersion: 2
+        x: 320
+        y: 254
+        width: 64
+        height: 64
+      alignment: 9
+      pivot: {x: 0.525, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: eabe1fd5a7c5b6b4692bbf5be73998c7
+      internalID: 1490086492
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Directional Sign 0
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 129
+        width: 64
+        height: 64
+      alignment: 9
+      pivot: {x: 0.525, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 5f37b0f34ca133043ba400e158841921
+      internalID: 263418143
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Directional Sign 1
+      rect:
+        serializedVersion: 2
+        x: 64
+        y: 129
+        width: 64
+        height: 64
+      alignment: 9
+      pivot: {x: 0.525, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: cf7b113382a51604d8929808b088682d
+      internalID: -1021008946
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Directional Sign 2
+      rect:
+        serializedVersion: 2
+        x: 128
+        y: 129
+        width: 64
+        height: 64
+      alignment: 9
+      pivot: {x: 0.525, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 4797f98838427b2429050277a39ca0ad
+      internalID: -1104087121
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Directional Sign 3
+      rect:
+        serializedVersion: 2
+        x: 192
+        y: 129
+        width: 64
+        height: 64
+      alignment: 9
+      pivot: {x: 0.525, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 811e604c12dae934a9653e77d823351f
+      internalID: 249226462
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Directional Sign 4
+      rect:
+        serializedVersion: 2
+        x: 256
+        y: 129
+        width: 64
+        height: 64
+      alignment: 9
+      pivot: {x: 0.525, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: a65809cae8617d749bcbe5ed2778866a
+      internalID: 1490453619
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Directional Sign 5
+      rect:
+        serializedVersion: 2
+        x: 320
+        y: 129
+        width: 64
+        height: 64
+      alignment: 9
+      pivot: {x: 0.525, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 80b11081b3b9dd0449e5e46fe9668efe
+      internalID: -1895191847
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
     outline: []
     physicsShape: []
     bones: []
@@ -274,12 +526,24 @@ TextureImporter:
     secondaryTextures: []
     nameFileIdTable:
       barrel_5: -761304557
+      Directional Sign 4: 1490453619
       barrel_1: -330289099
       barrel_2: -672781309
+      Sign 4: 557433799
+      Directional Sign 3: 249226462
+      Directional Sign 5: -1895191847
+      Sign 2: 869352581
+      Directional Sign 1: -1021008946
       barrel_0: 881957049
+      Sign 0: -251750564
+      Directional Sign 0: 263418143
+      Sign 3: -1802549372
+      Sign 1: -2127327079
       barrel_3: -257826623
       barrel_6: 2012514748
+      Directional Sign 2: -1104087121
       barrel_4: -430588310
+      Sign 5: 1490086492
   spritePackingTag: 
   pSDRemoveMatte: 0
   pSDShowRemoveMatteOption: 0

--- a/Assets/Dialogue Data/00 - Misc/Ruins Sign Dialogue.asset
+++ b/Assets/Dialogue Data/00 - Misc/Ruins Sign Dialogue.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4a29fe2c6e1452341a540e858dfdab48, type: 3}
+  m_Name: Ruins Sign Dialogue
+  m_EditorClassIdentifier: 
+  speakers: []
+  dialogues:
+  - title: Sign Dialogue
+    text: Here lies the ruins of the dark temple...
+    duration: 5
+    isSkippable: 1
+    speakerIndex: 0
+    isEnemyBubble: 0

--- a/Assets/Dialogue Data/00 - Misc/Ruins Sign Dialogue.asset.meta
+++ b/Assets/Dialogue Data/00 - Misc/Ruins Sign Dialogue.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b55cd4a165194b14aa90574014119b75
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Dialogue Data/00 - Misc/Temporary Sign - Route 2.asset
+++ b/Assets/Dialogue Data/00 - Misc/Temporary Sign - Route 2.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4a29fe2c6e1452341a540e858dfdab48, type: 3}
+  m_Name: Temporary Sign - Route 2
+  m_EditorClassIdentifier: 
+  speakers: []
+  dialogues:
+  - title: Sign Dialogue
+    text: this will be where the portal to the second route is... thanks for playing!
+    duration: 5
+    isSkippable: 1
+    speakerIndex: 0
+    isEnemyBubble: 0

--- a/Assets/Dialogue Data/00 - Misc/Temporary Sign - Route 2.asset.meta
+++ b/Assets/Dialogue Data/00 - Misc/Temporary Sign - Route 2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 91325f2cef84ed844babfc8195d1e372
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Dialogue Data/00 - Misc/Temporary Sign - Route 3.asset
+++ b/Assets/Dialogue Data/00 - Misc/Temporary Sign - Route 3.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4a29fe2c6e1452341a540e858dfdab48, type: 3}
+  m_Name: Temporary Sign - Route 3
+  m_EditorClassIdentifier: 
+  speakers: []
+  dialogues:
+  - title: Sign Dialogue
+    text: this will be where the portal to the third route is... thanks for playing!
+    duration: 5
+    isSkippable: 1
+    speakerIndex: 0
+    isEnemyBubble: 0

--- a/Assets/Dialogue Data/00 - Misc/Temporary Sign - Route 3.asset.meta
+++ b/Assets/Dialogue Data/00 - Misc/Temporary Sign - Route 3.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0653bef5a50a2d44ab0cd3f80368daec
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Interactible/Breakable Directional Sign.prefab
+++ b/Assets/Prefabs/Interactible/Breakable Directional Sign.prefab
@@ -1,0 +1,269 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &9072684245809922704
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9072684245809922711}
+  - component: {fileID: 9072684245809922710}
+  - component: {fileID: 9072684245809922705}
+  - component: {fileID: 9072684245809922730}
+  - component: {fileID: 9072684245809922709}
+  - component: {fileID: 9072684245809922708}
+  - component: {fileID: 9072684245809922731}
+  - component: {fileID: 1228182445627252493}
+  m_Layer: 8
+  m_Name: Breakable Directional Sign
+  m_TagString: Breakable
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &9072684245809922711
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9072684245809922704}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.0033495426, y: -0.504, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 9072684246960212527}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &9072684245809922710
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9072684245809922704}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -1057762475
+  m_SortingLayer: 3
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 263418143, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.64, y: 0.64}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!95 &9072684245809922705
+Animator:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9072684245809922704}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 2d5ef556d8834b644b55e5ebd6c65562, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorControllerStateOnDisable: 0
+--- !u!61 &9072684245809922730
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9072684245809922704}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: -0.000687249, y: -0.0326671}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.525, y: 0.5}
+    oldSize: {x: 0.64, y: 0.64}
+    newSize: {x: 0.64, y: 0.64}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.21328528, y: 0.16632628}
+  m_EdgeRadius: 0
+--- !u!114 &9072684245809922709
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9072684245809922704}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2e58c267cd4ef09409f30c564b9ca1d6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  immuneTime: 1
+  maxHitPoints: 1
+  currentHitPoints: 1
+--- !u!114 &9072684245809922708
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9072684245809922704}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1593997ecc91a534ea43a220f9b9b21b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  breakAnimationDuration: 0.5
+  destroyAfterBreaking: 0
+--- !u!114 &9072684245809922731
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9072684245809922704}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d021743454fa5c48abb9134eed67832, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  dialogue: {fileID: 0}
+  playerCheck: {fileID: 9072684246960212521}
+  isBreakableSign: 1
+--- !u!114 &1228182445627252493
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9072684245809922704}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b2b68a93e6d46a94da7e0f682e00d908, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &9072684246960212520
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9072684246960212527}
+  - component: {fileID: 9072684246960212521}
+  - component: {fileID: 9072684246960212526}
+  m_Layer: 0
+  m_Name: PlayerCheck
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &9072684246960212527
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9072684246960212520}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 9072684245809922711}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &9072684246960212521
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9072684246960212520}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c693660466f7ac04ea8cbdde54a5deba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  isColliding: 0
+  tagsToCheck:
+  - Player
+--- !u!61 &9072684246960212526
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9072684246960212520}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0.1917693}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1.3, y: 0.6164614}
+  m_EdgeRadius: 0

--- a/Assets/Prefabs/Interactible/Breakable Directional Sign.prefab.meta
+++ b/Assets/Prefabs/Interactible/Breakable Directional Sign.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2d0d33f4b7b9acb46b07d8720a80d0e3
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Interactible/Breakable Sign.prefab
+++ b/Assets/Prefabs/Interactible/Breakable Sign.prefab
@@ -1,0 +1,269 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &304442816937835841
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 304442816937835842}
+  - component: {fileID: 304442816937835843}
+  - component: {fileID: 304442816937835840}
+  - component: {fileID: 304442816937835845}
+  - component: {fileID: 304442816937835846}
+  - component: {fileID: 304442816937835847}
+  - component: {fileID: 304442816937835844}
+  - component: {fileID: 9062436444421138188}
+  m_Layer: 8
+  m_Name: Breakable Sign
+  m_TagString: Breakable
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &304442816937835842
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 304442816937835841}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -14.579527, y: -3.72, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 304442817265159275}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &304442816937835843
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 304442816937835841}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -845277557
+  m_SortingLayer: 5
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -251750564, guid: 5a6d1f992b82ac744bda5b6faf0c2509, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.64, y: 0.64}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!95 &304442816937835840
+Animator:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 304442816937835841}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 2df85185006926a4c9e9047ea7d10820, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorControllerStateOnDisable: 0
+--- !u!61 &304442816937835845
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 304442816937835841}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: -0.0075387955, y: 0.011846304}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.525, y: 0.5}
+    oldSize: {x: 0.64, y: 0.64}
+    newSize: {x: 0.64, y: 0.64}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.21691704, y: 0.18983984}
+  m_EdgeRadius: 0
+--- !u!114 &304442816937835846
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 304442816937835841}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2e58c267cd4ef09409f30c564b9ca1d6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  immuneTime: 1
+  maxHitPoints: 1
+  currentHitPoints: 1
+--- !u!114 &304442816937835847
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 304442816937835841}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1593997ecc91a534ea43a220f9b9b21b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  breakAnimationDuration: 0.5
+  destroyAfterBreaking: 0
+--- !u!114 &304442816937835844
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 304442816937835841}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d021743454fa5c48abb9134eed67832, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  dialogue: {fileID: 0}
+  playerCheck: {fileID: 304442817265159274}
+  isBreakableSign: 1
+--- !u!114 &9062436444421138188
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 304442816937835841}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b2b68a93e6d46a94da7e0f682e00d908, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &304442817265159272
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 304442817265159275}
+  - component: {fileID: 304442817265159277}
+  - component: {fileID: 304442817265159274}
+  m_Layer: 0
+  m_Name: PlayerCheck
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &304442817265159275
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 304442817265159272}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 304442816937835842}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &304442817265159277
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 304442817265159272}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0.123540044}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1.3, y: 0.42122293}
+  m_EdgeRadius: 0
+--- !u!114 &304442817265159274
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 304442817265159272}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c693660466f7ac04ea8cbdde54a5deba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  isColliding: 0
+  tagsToCheck:
+  - Player

--- a/Assets/Prefabs/Interactible/Breakable Sign.prefab.meta
+++ b/Assets/Prefabs/Interactible/Breakable Sign.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 74a5d31355ae7e44c9894bb49a226788
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -35329,6 +35329,72 @@ Tilemap:
     e31: 0
     e32: 0
     e33: 1
+--- !u!1001 &195469813
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1875368062}
+    m_Modifications:
+    - target: {fileID: 9072684245809922704, guid: 2d0d33f4b7b9acb46b07d8720a80d0e3, type: 3}
+      propertyPath: m_Name
+      value: Directional Sign - Route 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 9072684245809922711, guid: 2d0d33f4b7b9acb46b07d8720a80d0e3, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9072684245809922711, guid: 2d0d33f4b7b9acb46b07d8720a80d0e3, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 15.860535
+      objectReference: {fileID: 0}
+    - target: {fileID: 9072684245809922711, guid: 2d0d33f4b7b9acb46b07d8720a80d0e3, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 8.391087
+      objectReference: {fileID: 0}
+    - target: {fileID: 9072684245809922711, guid: 2d0d33f4b7b9acb46b07d8720a80d0e3, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.05207606
+      objectReference: {fileID: 0}
+    - target: {fileID: 9072684245809922711, guid: 2d0d33f4b7b9acb46b07d8720a80d0e3, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9072684245809922711, guid: 2d0d33f4b7b9acb46b07d8720a80d0e3, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9072684245809922711, guid: 2d0d33f4b7b9acb46b07d8720a80d0e3, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9072684245809922711, guid: 2d0d33f4b7b9acb46b07d8720a80d0e3, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9072684245809922711, guid: 2d0d33f4b7b9acb46b07d8720a80d0e3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9072684245809922711, guid: 2d0d33f4b7b9acb46b07d8720a80d0e3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9072684245809922711, guid: 2d0d33f4b7b9acb46b07d8720a80d0e3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9072684245809922731, guid: 2d0d33f4b7b9acb46b07d8720a80d0e3, type: 3}
+      propertyPath: dialogue
+      value: 
+      objectReference: {fileID: 11400000, guid: 0653bef5a50a2d44ab0cd3f80368daec, type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2d0d33f4b7b9acb46b07d8720a80d0e3, type: 3}
+--- !u!4 &195469814 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9072684245809922711, guid: 2d0d33f4b7b9acb46b07d8720a80d0e3, type: 3}
+  m_PrefabInstance: {fileID: 195469813}
+  m_PrefabAsset: {fileID: 0}
 --- !u!224 &200366022 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 5385116824661687199, guid: 657bca29774769c4f939f48094ba1c15, type: 3}
@@ -35345,6 +35411,76 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: af8f9c72add913d4bb17e5b0fb936fe7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &208552308
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 621439026}
+    m_Modifications:
+    - target: {fileID: 2404355901149569652, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_SortingLayer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569652, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_SortingLayerID
+      value: -1057762475
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 14.930534
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.12267637
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.05207606
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569655, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_Name
+      value: Tree (3)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+--- !u!4 &208552309 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+  m_PrefabInstance: {fileID: 208552308}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &209023011
 GameObject:
   m_ObjectHideFlags: 0
@@ -35394,6 +35530,64 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 2102027488352298946, guid: 7a547ad780afc5942a4be6892335e9b9, type: 3}
   m_PrefabInstance: {fileID: 2102027488392276716}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &266047768
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 266047769}
+  - component: {fileID: 266047770}
+  m_Layer: 0
+  m_Name: Left Side
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &266047769
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 266047768}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -14.87, y: 3.44, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1414396745}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &266047770
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 266047768}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 6200000, guid: 18512d9c28574ca4f9157986b58aa5a8, type: 2}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.3, y: 10}
+  m_EdgeRadius: 0
 --- !u!1001 &266330827
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -35919,10 +36113,9 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1473514256}
-  - {fileID: 574403036}
-  - {fileID: 1712199542}
-  - {fileID: 1022977146}
+  - {fileID: 1875368062}
+  - {fileID: 1002186636}
+  - {fileID: 971137430}
   m_Father: {fileID: 927397046}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -35955,7 +36148,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 553219873}
+  m_Father: {fileID: 1002186636}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &574403037
@@ -36113,6 +36306,42 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1.1974587, y: 0.18022543}
   m_EdgeRadius: 0
+--- !u!1 &621439025
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 621439026}
+  m_Layer: 0
+  m_Name: Tree Container
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &621439026
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 621439025}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1536288727}
+  - {fileID: 762701120}
+  - {fileID: 1681852781}
+  - {fileID: 208552309}
+  - {fileID: 918033731}
+  m_Father: {fileID: 971137430}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &631578873
 GameObject:
   m_ObjectHideFlags: 3
@@ -36387,6 +36616,64 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 44a4d93aa262b7a499ef0f583b1e008d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &656047586
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 656047587}
+  - component: {fileID: 656047588}
+  m_Layer: 0
+  m_Name: Right Side
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &656047587
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 656047586}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 22.63, y: 4.04, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1414396745}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &656047588
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 656047586}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 6200000, guid: 18512d9c28574ca4f9157986b58aa5a8, type: 2}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.3, y: 10}
+  m_EdgeRadius: 0
 --- !u!1 &661296816 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4697750405587687979, guid: da2b955bb7d5a7c43a29028653e8dd83, type: 3}
@@ -36727,6 +37014,76 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 4746181395301647912, guid: 1c5bc475b7899a2498e5d712a81126c1, type: 3}
   m_PrefabInstance: {fileID: 724806310}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &762701119
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 621439026}
+    m_Modifications:
+    - target: {fileID: 2404355901149569652, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_SortingLayer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569652, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_SortingLayerID
+      value: -1057762475
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 14.3105345
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.12267637
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.05207606
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569655, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_Name
+      value: Tree (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+--- !u!4 &762701120 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+  m_PrefabInstance: {fileID: 762701119}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &771643757
 GameObject:
   m_ObjectHideFlags: 0
@@ -36795,6 +37152,76 @@ PolygonCollider2D:
       - {x: 22.611982, y: -1.1294549}
       - {x: 22.60782, y: 10.828733}
       - {x: 8.624237, y: 10.759158}
+--- !u!1001 &811390292
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1895418775}
+    m_Modifications:
+    - target: {fileID: 4321194960432047498, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_Name
+      value: Stone - Big (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -4.7194653
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.1227138
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.05207606
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+--- !u!4 &811390293 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+  m_PrefabInstance: {fileID: 811390292}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &837778022
 GameObject:
   m_ObjectHideFlags: 0
@@ -37121,6 +37548,76 @@ Transform:
   m_Father: {fileID: 927397046}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &918033730
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 621439026}
+    m_Modifications:
+    - target: {fileID: 2404355901149569652, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_SortingLayer
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569652, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_SortingLayerID
+      value: -1057762475
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 18.230534
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.12267637
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.05207606
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569655, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_Name
+      value: Tree (4)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+--- !u!4 &918033731 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+  m_PrefabInstance: {fileID: 918033730}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &927397045
 GameObject:
   m_ObjectHideFlags: 0
@@ -37154,9 +37651,109 @@ Transform:
   - {fileID: 1279789629}
   - {fileID: 911895030}
   - {fileID: 553219873}
+  - {fileID: 1414396745}
   m_Father: {fileID: 209023012}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &971137429
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 971137430}
+  m_Layer: 0
+  m_Name: Others Container
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &971137430
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 971137429}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 621439026}
+  - {fileID: 1895418775}
+  m_Father: {fileID: 553219873}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &989481077
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1895418775}
+    m_Modifications:
+    - target: {fileID: 4321194960432047498, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_Name
+      value: Stone - Big (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.379466
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.0259137
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.05207606
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047541, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_SortingOrder
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+--- !u!4 &989481078 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+  m_PrefabInstance: {fileID: 989481077}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &990758968
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -37214,6 +37811,41 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: edfd647152798c34199fcc3b9c0d1b4d, type: 3}
+--- !u!1 &1002186635
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1002186636}
+  m_Layer: 0
+  m_Name: House Container
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1002186636
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1002186635}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1473514256}
+  - {fileID: 574403036}
+  - {fileID: 1712199542}
+  - {fileID: 1022977146}
+  m_Father: {fileID: 553219873}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1022977145
 GameObject:
   m_ObjectHideFlags: 0
@@ -37243,7 +37875,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 553219873}
+  m_Father: {fileID: 1002186636}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &1022977147
@@ -37374,6 +38006,72 @@ BoxCollider2D:
 Transform:
   m_CorrespondingSourceObject: {fileID: 5222524543507999360, guid: 7d8e735844ac5864186d371d33b8ca8e, type: 3}
   m_PrefabInstance: {fileID: 387317031}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1063181239
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1895418775}
+    m_Modifications:
+    - target: {fileID: 4321194960432047498, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_Name
+      value: Stone - Big
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -11.924801
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.0259137
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.05207606
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047541, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_SortingOrder
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+--- !u!4 &1063181240 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+  m_PrefabInstance: {fileID: 1063181239}
   m_PrefabAsset: {fileID: 0}
 --- !u!4 &1077099414 stripped
 Transform:
@@ -38254,6 +38952,39 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 875180814980714057, guid: 2f0a352a193a3d94a9e2b8936a36db14, type: 3}
   m_PrefabInstance: {fileID: 1773023177}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1414396744
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1414396745}
+  m_Layer: 0
+  m_Name: Scene Limits Colliders
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1414396745
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1414396744}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 266047769}
+  - {fileID: 656047587}
+  m_Father: {fileID: 927397046}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1462819825
 GameObject:
   m_ObjectHideFlags: 0
@@ -38651,6 +39382,72 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: eb80094e4095bbb4aa4ff7790fe0d3e9, type: 3}
+--- !u!1001 &1536288726
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 621439026}
+    m_Modifications:
+    - target: {fileID: 2404355901149569652, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_SortingOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 18.470535
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.12267637
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.05207606
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569655, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_Name
+      value: Tree
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+--- !u!4 &1536288727 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+  m_PrefabInstance: {fileID: 1536288726}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1540400029
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -39496,6 +40293,72 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1.5248575, y: 0.13651013}
   m_EdgeRadius: 0
+--- !u!1001 &1681852780
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 621439026}
+    m_Modifications:
+    - target: {fileID: 2404355901149569652, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_SortingOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 14.660534
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.12267637
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.05207606
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2404355901149569655, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+      propertyPath: m_Name
+      value: Tree (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+--- !u!4 &1681852781 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2404355901149569653, guid: 30a5fd46b0daeb64d9dd8be2003fceea, type: 3}
+  m_PrefabInstance: {fileID: 1681852780}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1699463252
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -39620,6 +40483,68 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4697750405587687972, guid: da2b955bb7d5a7c43a29028653e8dd83, type: 3}
   m_PrefabInstance: {fileID: 1708248213}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1712092584
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1895418775}
+    m_Modifications:
+    - target: {fileID: 4321194960432047498, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_Name
+      value: Stone - Big (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -7.249466
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.0339136
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.05207606
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+--- !u!4 &1712092585 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+  m_PrefabInstance: {fileID: 1712092584}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1712199541
 GameObject:
   m_ObjectHideFlags: 0
@@ -39649,7 +40574,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 553219873}
+  m_Father: {fileID: 1002186636}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &1712199543
@@ -40526,6 +41451,68 @@ Transform:
   m_Father: {fileID: 927397046}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1817888479
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1895418775}
+    m_Modifications:
+    - target: {fileID: 4321194960432047498, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_Name
+      value: Stone - Big (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.1304655
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.8309138
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.05207606
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+--- !u!4 &1817888480 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+  m_PrefabInstance: {fileID: 1817888479}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1819715827
 GameObject:
   m_ObjectHideFlags: 0
@@ -40851,6 +41838,40 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1.0813136, y: 0.08199704}
   m_EdgeRadius: 0
+--- !u!1 &1875368061
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1875368062}
+  m_Layer: 0
+  m_Name: Sign Container
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1875368062
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1875368061}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2127126109}
+  - {fileID: 195469814}
+  - {fileID: 1958665771}
+  m_Father: {fileID: 553219873}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1892734339
 GameObject:
   m_ObjectHideFlags: 0
@@ -40923,6 +41944,48 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.87336683, y: 0.15165663}
   m_EdgeRadius: 0
+--- !u!1 &1895418774
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1895418775}
+  m_Layer: 0
+  m_Name: Rock Container
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1895418775
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1895418774}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1063181240}
+  - {fileID: 989481078}
+  - {fileID: 1817888480}
+  - {fileID: 2128537145}
+  - {fileID: 1712092585}
+  - {fileID: 811390293}
+  m_Father: {fileID: 971137430}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &1958665771 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 304442816937835842, guid: 74a5d31355ae7e44c9894bb49a226788, type: 3}
+  m_PrefabInstance: {fileID: 304442818737300329}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1969977249 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3869175445727238962, guid: 0caa6df864b121f43aa2f23574dde166, type: 3}
@@ -41883,6 +42946,73 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 7838359911046812374, guid: edfd647152798c34199fcc3b9c0d1b4d, type: 3}
   m_PrefabInstance: {fileID: 1699463252}
   m_PrefabAsset: {fileID: 0}
+--- !u!4 &2127126109 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9072684245809922711, guid: 2d0d33f4b7b9acb46b07d8720a80d0e3, type: 3}
+  m_PrefabInstance: {fileID: 9072684246904200394}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2128537144
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1895418775}
+    m_Modifications:
+    - target: {fileID: 4321194960432047498, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_Name
+      value: Stone - Big (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -7.6894655
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.0339136
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.05207606
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+--- !u!4 &2128537145 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4321194960432047540, guid: cbfbe6766b17ff2428fac9a4d13a6ee8, type: 3}
+  m_PrefabInstance: {fileID: 2128537144}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &2145032260
 GameObject:
   m_ObjectHideFlags: 0
@@ -41955,6 +43085,67 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.32291317, y: 0.17405534}
   m_EdgeRadius: 0
+--- !u!1001 &304442818737300329
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1875368062}
+    m_Modifications:
+    - target: {fileID: 304442816937835841, guid: 74a5d31355ae7e44c9894bb49a226788, type: 3}
+      propertyPath: m_Name
+      value: Breakable Sign
+      objectReference: {fileID: 0}
+    - target: {fileID: 304442816937835842, guid: 74a5d31355ae7e44c9894bb49a226788, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 304442816937835842, guid: 74a5d31355ae7e44c9894bb49a226788, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -11.068993
+      objectReference: {fileID: 0}
+    - target: {fileID: 304442816937835842, guid: 74a5d31355ae7e44c9894bb49a226788, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.1339138
+      objectReference: {fileID: 0}
+    - target: {fileID: 304442816937835842, guid: 74a5d31355ae7e44c9894bb49a226788, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.05207606
+      objectReference: {fileID: 0}
+    - target: {fileID: 304442816937835842, guid: 74a5d31355ae7e44c9894bb49a226788, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 304442816937835842, guid: 74a5d31355ae7e44c9894bb49a226788, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 304442816937835842, guid: 74a5d31355ae7e44c9894bb49a226788, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 304442816937835842, guid: 74a5d31355ae7e44c9894bb49a226788, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 304442816937835842, guid: 74a5d31355ae7e44c9894bb49a226788, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 304442816937835842, guid: 74a5d31355ae7e44c9894bb49a226788, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 304442816937835842, guid: 74a5d31355ae7e44c9894bb49a226788, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 304442816937835844, guid: 74a5d31355ae7e44c9894bb49a226788, type: 3}
+      propertyPath: dialogue
+      value: 
+      objectReference: {fileID: 11400000, guid: b55cd4a165194b14aa90574014119b75, type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 74a5d31355ae7e44c9894bb49a226788, type: 3}
 --- !u!1001 &373794723157505224
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -42021,7 +43212,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 553219873}
+    m_TransformParent: {fileID: 1002186636}
     m_Modifications:
     - target: {fileID: 873534903762757833, guid: b4a4434008fc70045bcf5101c814c169, type: 3}
       propertyPath: m_RootOrder
@@ -42567,3 +43758,64 @@ MonoBehaviour:
   - Player
   sceneName: Route 1
   fightingRoute: 1
+--- !u!1001 &9072684246904200394
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1875368062}
+    m_Modifications:
+    - target: {fileID: 9072684245809922704, guid: 2d0d33f4b7b9acb46b07d8720a80d0e3, type: 3}
+      propertyPath: m_Name
+      value: Directional Sign - Route 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 9072684245809922711, guid: 2d0d33f4b7b9acb46b07d8720a80d0e3, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9072684245809922711, guid: 2d0d33f4b7b9acb46b07d8720a80d0e3, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.6194658
+      objectReference: {fileID: 0}
+    - target: {fileID: 9072684245809922711, guid: 2d0d33f4b7b9acb46b07d8720a80d0e3, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 5.3980865
+      objectReference: {fileID: 0}
+    - target: {fileID: 9072684245809922711, guid: 2d0d33f4b7b9acb46b07d8720a80d0e3, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.05207606
+      objectReference: {fileID: 0}
+    - target: {fileID: 9072684245809922711, guid: 2d0d33f4b7b9acb46b07d8720a80d0e3, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9072684245809922711, guid: 2d0d33f4b7b9acb46b07d8720a80d0e3, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9072684245809922711, guid: 2d0d33f4b7b9acb46b07d8720a80d0e3, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9072684245809922711, guid: 2d0d33f4b7b9acb46b07d8720a80d0e3, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9072684245809922711, guid: 2d0d33f4b7b9acb46b07d8720a80d0e3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9072684245809922711, guid: 2d0d33f4b7b9acb46b07d8720a80d0e3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9072684245809922711, guid: 2d0d33f4b7b9acb46b07d8720a80d0e3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9072684245809922731, guid: 2d0d33f4b7b9acb46b07d8720a80d0e3, type: 3}
+      propertyPath: dialogue
+      value: 
+      objectReference: {fileID: 11400000, guid: 91325f2cef84ed844babfc8195d1e372, type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2d0d33f4b7b9acb46b07d8720a80d0e3, type: 3}

--- a/Assets/Scripts/Damage/DamageReceiver.cs
+++ b/Assets/Scripts/Damage/DamageReceiver.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 public class DamageReceiver : MonoBehaviour
 {
-    [SerializeField] private Animator animator;
+    private Animator animator;
 
     [SerializeField] private float immuneTime = 1f;
     private bool isImmune = false;
@@ -64,6 +64,8 @@ public class DamageReceiver : MonoBehaviour
     private void Awake()
     {
         currentHitPoints = maxHitPoints;
+
+        animator = GetComponent<Animator>();
     }
 
     protected virtual void ReceiveDamage(Damage damage)

--- a/Assets/Scripts/Interactible/BreakableObject.cs
+++ b/Assets/Scripts/Interactible/BreakableObject.cs
@@ -7,6 +7,9 @@ public class BreakableObject : MonoBehaviour
 {
     private Animator animator;
 
+    [SerializeField] float breakAnimationDuration = .6f;
+    [SerializeField] bool destroyAfterBreaking = true;
+
     private void Start()
     {
         animator = GetComponent<Animator>();
@@ -18,12 +21,13 @@ public class BreakableObject : MonoBehaviour
     {
         animator.SetTrigger(Config.ANIMATOR_DEATH_TRIGGER);
          
-        StartCoroutine(WaitToDestroy());
+        if (destroyAfterBreaking)
+            StartCoroutine(WaitToDestroy());
     }
 
     private IEnumerator WaitToDestroy()
     {
-        yield return new WaitForSeconds(.6f);
+        yield return new WaitForSeconds(breakAnimationDuration);
 
         Destroy(gameObject);
     }

--- a/Assets/Scripts/Interactible/Colliders/BoxCollider.cs
+++ b/Assets/Scripts/Interactible/Colliders/BoxCollider.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+[RequireComponent(typeof(BoxCollider2D))]
 public class BoxCollider : GeneralCollider
 {
     protected BoxCollider2D boxCollider;

--- a/Assets/Scripts/Interactible/Colliders/CircleCollider.cs
+++ b/Assets/Scripts/Interactible/Colliders/CircleCollider.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+[RequireComponent(typeof(CircleCollider2D))]
 public class CircleCollider : GeneralCollider
 {
     private CircleCollider2D circleCollider;

--- a/Assets/Scripts/Interactible/Sign.cs
+++ b/Assets/Scripts/Interactible/Sign.cs
@@ -1,0 +1,39 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Sign : MonoBehaviour
+{
+    [SerializeField] private DialogueObject dialogue;
+    [SerializeField] private BoxCollider playerCheck;
+
+    [SerializeField] private bool isBreakableSign = true;
+    private bool isBroken = false;
+
+    private void Start()
+    {
+        if (isBreakableSign)
+            GetComponent<DamageReceiver>().OnCharacterAliveStatusChange += SignBroken;
+    }
+
+    private void Update()
+    {
+        if (!isBroken && playerCheck != null)
+        {
+            if (!GameManager.instance.GetDialogueManager().IsRunning && playerCheck.IsColliding())
+            {
+                if (Input.GetKeyDown(KeyCode.Space))
+                {
+                    // TODO: Change later for canvas dialogue
+                    GameManager.instance.GetDialogueManager().RunBubbleDialogue(dialogue, new List<Transform>() { transform });
+                }
+            }
+        }
+    }
+
+    private void SignBroken()
+    {
+        if (!GetComponent<DamageReceiver>().IsAlive)
+            isBroken = true;
+    }
+}

--- a/Assets/Scripts/Interactible/Sign.cs.meta
+++ b/Assets/Scripts/Interactible/Sign.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8d021743454fa5c48abb9134eed67832
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Managers/LevelLoader.cs
+++ b/Assets/Scripts/Managers/LevelLoader.cs
@@ -111,11 +111,16 @@ public class LevelLoader : MonoBehaviour
 
     private void SetPlayerVariablesAfterTransition()
     {
-        GameManager.instance.GetPlayer().GetComponent<Animator>().enabled = true;
-        GameManager.instance.GetPlayer().transform.localScale = Vector3.one;
+        GameObject player = GameManager.instance.GetPlayer();
+
+        player.GetComponent<Animator>().enabled = true;
+        player.transform.localScale = Vector3.one;
         GameManager.instance.RestartPlayer();
 
-        GameManager.instance.GetPlayer().GetComponent<Rigidbody2D>().constraints = RigidbodyConstraints2D.FreezeRotation;
+        player.GetComponent<Rigidbody2D>().constraints = RigidbodyConstraints2D.FreezeRotation;
+
+        player.GetComponent<PlayerAttackController>().enabled = true;
+        player.GetComponent<PlayerMovementController>().enabled = true;
     }
 
     public Animator GetCrossfadeAnimator()

--- a/Assets/Timelines/02 First Fighting Route/14_slyTeleport.playable
+++ b/Assets/Timelines/02 First Fighting Route/14_slyTeleport.playable
@@ -655,7 +655,7 @@ MonoBehaviour:
   m_Children: []
   m_Clips:
   - m_Version: 1
-    m_Start: 0.5
+    m_Start: 0.2833333333333333
     m_ClipIn: 0
     m_Asset: {fileID: -420188527345820503}
     m_Duration: 6.0751473922902495

--- a/Assets/ZResources/ZSerializer/GlobalObjects/Resources/Settings.asset
+++ b/Assets/ZResources/ZSerializer/GlobalObjects/Resources/Settings.asset
@@ -12,20 +12,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 17526797d331c334d804f96cc09d54c4, type: 3}
   m_Name: Settings
   m_EditorClassIdentifier: 
-  newGameIndex: 16
-  savedGamesAmount: 3
-  currentSavedGames: 0a0000000e0000000f000000
+  newGameIndex: 0
+  savedGamesAmount: 0
+  currentSavedGames: 
   savedGamesKillsCounterSerialized:
-    keys: 0a0000000e0000000f000000
-    values: 000000001f00000003000000
+    keys: 
+    values: 
   savedGamesDeathsCounterSerialized:
-    keys: 0a0000000e0000000f000000
-    values: 000000000400000000000000
+    keys: 
+    values: 
   savedGamesTimePlayedCounterSerialized:
-    keys: 0a0000000e0000000f000000
-    values:
-    - 0
-    - 268.91617
-    - 51.364014
+    keys: 
+    values: []
   musicVolume: 1
-  SFXVolume: 0.39999992
+  SFXVolume: 1


### PR DESCRIPTION
- Added `Sign` script
- Added `Breakable Directional Sign`, `Breakable Sign` prefabs
- Added dialogues for all the signs created
- Fixed player movement and attack controllers back to enabled after loading a new scene (before it would remain disabled if going to main menu when in a cutscene, for example)
- Added rocks and trees in main scene, to give it a little bit more of life