### PR TITLE
First Route Music Bug

### DIFF
--- a/Assets/Resources/Materials/SpriteFlash.mat
+++ b/Assets/Resources/Materials/SpriteFlash.mat
@@ -75,6 +75,6 @@ Material:
     - _UVSec: 0
     - _ZWrite: 1
     m_Colors:
-    - _Color: {r: 0.33333334, g: 0.0627451, b: 0.043137256, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
   m_BuildTextureStacks: []

--- a/Assets/Scripts/Managers/MusicManager.cs
+++ b/Assets/Scripts/Managers/MusicManager.cs
@@ -118,20 +118,18 @@ public class MusicManager : MonoBehaviour
 
         for (int i = 0; i < firstFightingRouteTracks.Length; i++)
         {
-            while (audioSource.isPlaying)
+            while (AudioSettings.dspTime < startTime)
                 yield return null;
 
             AudioClip clipToSchedule = firstFightingRouteTracks[i];
 
             audioSource.clip = clipToSchedule;
-            audioSource.PlayScheduled(startTime);
+
+            audioSource.Play();
 
             double duration = (double)clipToSchedule.samples / clipToSchedule.frequency;
 
             startTime += duration;
-
-            if (!audioSource.isPlaying)
-                audioSource.Play();
         }
 
         while (audioSource.isPlaying)


### PR DESCRIPTION
There was a problem in which when we left the game window and went to any other program, after coming back to our game the music would stop until the next track was played. 

To solve this, instead of using the `PlayScheduled` method of the `AudioSource` component, I'm using the normal `Play` method and doing the waiting outside, checking if the `AudioSettings.dspTime` is lower than the time it would take for the current track to finish, and when finished, change it to the next one.