### PR TITLE
Earthen Hands Update

### DIFF
--- a/Assets/Prefabs/Projectiles/Earthen Hands.prefab
+++ b/Assets/Prefabs/Projectiles/Earthen Hands.prefab
@@ -164,6 +164,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2104d8446e348bf4ab98c8955e193eda, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  movingSpeed: 0.05
 --- !u!114 &7610356405838339567
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -39827,6 +39827,11 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 8106663203899359985, guid: 3e4c3e90a7c61324b8ce89ecae976c0b, type: 3}
   m_PrefabInstance: {fileID: 1226828869}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1226828871 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8106663203899359994, guid: 3e4c3e90a7c61324b8ce89ecae976c0b, type: 3}
+  m_PrefabInstance: {fileID: 1226828869}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1240475568
 GameObject:
   m_ObjectHideFlags: 0
@@ -40366,7 +40371,7 @@ MonoBehaviour:
   mainMenu: {fileID: 724806313}
   mainMenuUI: {fileID: 724806312}
   pauseMenu: {fileID: 1989928203}
-  pauseMenuFightingRoute: {fileID: 0}
+  pauseMenuFightingRoute: {fileID: 1226828871}
   countersUI: {fileID: 200366023}
   isOnMainMenu: 0
   isGamePaused: 0

--- a/Assets/Scenes/Route 1.unity
+++ b/Assets/Scenes/Route 1.unity
@@ -8595,6 +8595,11 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 8106663203899359985, guid: 3e4c3e90a7c61324b8ce89ecae976c0b, type: 3}
   m_PrefabInstance: {fileID: 262408952}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &262408954 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8106663203899359994, guid: 3e4c3e90a7c61324b8ce89ecae976c0b, type: 3}
+  m_PrefabInstance: {fileID: 262408952}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &272697793
 GameObject:
   m_ObjectHideFlags: 0
@@ -35727,7 +35732,7 @@ MonoBehaviour:
   mainMenu: {fileID: 2096627361}
   mainMenuUI: {fileID: 2096627360}
   pauseMenu: {fileID: 1816972621}
-  pauseMenuFightingRoute: {fileID: 0}
+  pauseMenuFightingRoute: {fileID: 262408954}
   countersUI: {fileID: 1009155021}
   isOnMainMenu: 1
   isGamePaused: 0
@@ -61503,11 +61508,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   frames:
   - {fileID: 1368459968}
+  - {fileID: 1403479523}
   - {fileID: 2071746091}
   - {fileID: 329032152}
   - {fileID: 1035707527}
   - {fileID: 761324798}
-  - {fileID: 1403479523}
   - {fileID: 420930561}
 --- !u!1 &1616341461
 GameObject:

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -206,6 +206,8 @@ public class GameManager : MonoBehaviour
     {
         FrameManager frameManager = GameObject.FindGameObjectWithTag(Config.FRAME_MANAGER_TAG).GetComponent<FrameManager>();
 
+        dialogueManager.ClearDialogues();
+        animationManager.ClearCanvases();
         StartCoroutine(frameManager.RestartFrame());
     }
 

--- a/Assets/Scripts/Projectiles/EarthenHands.cs
+++ b/Assets/Scripts/Projectiles/EarthenHands.cs
@@ -13,6 +13,8 @@ public class EarthenHands : MonoBehaviour
 
     private bool isFollowing = true;
 
+    [SerializeField] float movingSpeed = .01f; 
+
 
     private void Start()
     {
@@ -58,7 +60,16 @@ public class EarthenHands : MonoBehaviour
     {
         Vector3 lookatPreviousPosition = lookatPreviousPositions.Dequeue();
 
-        transform.position = new Vector3(lookatPreviousPosition.x, transform.position.y, transform.position.z);
+        //transform.position = new Vector3(lookatPreviousPosition.x, transform.position.y, transform.position.z);
+
+        float relativePlayerPositionX = lookatPreviousPosition.x - transform.position.x;
+        int directionToMove = 1;
+
+        if (relativePlayerPositionX < 0)
+            directionToMove = -1;
+
+        if (Mathf.Abs(relativePlayerPositionX) > .1f)
+            transform.position = transform.position + (Vector3.right * directionToMove * movingSpeed);
     }
 
     private void CatchPlayer()

--- a/Assets/ZResources/ZSerializer/GlobalObjects/Resources/Settings.asset
+++ b/Assets/ZResources/ZSerializer/GlobalObjects/Resources/Settings.asset
@@ -24,5 +24,5 @@ MonoBehaviour:
   savedGamesTimePlayedCounterSerialized:
     keys: 
     values: []
-  musicVolume: 1
-  SFXVolume: 1
+  musicVolume: 0
+  SFXVolume: 0.4999999


### PR DESCRIPTION
- Updated movement of earthen hands

**Important note:**

Before, the movement of the earthen hands attack was just taking the position of the player on the previous frame, following the player for one second. That led to some problems when dashing, since the hands would dash with the player too. Now it'll move in the direction the player was on the previous frame, using the same `Queue`, but changing the position of the hands with certain speed frame by frame.